### PR TITLE
fix(docs): correct pnpm version and storybook script name in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This is a pnpm + Turborepo monorepo (`@winter-love/web`). The main app is **Coon
 
 ### Prerequisites
 
-- Node.js 22, pnpm 10.26.1 (both specified in `package.json` `engines` / `packageManager`)
+- Node.js 22, pnpm 10.33.2 (both specified in `package.json` `engines` / `packageManager`)
 - `pnpm install` runs `postinstall` (sorts package.json) and `prepare` (builds all `@winter-love/*` packages via Turborepo) automatically
 
 ### Running services
@@ -16,7 +16,7 @@ This is a pnpm + Turborepo monorepo (`@winter-love/web`). The main app is **Coon
 | Service   | Command                          | Port | Notes                                                                      |
 | --------- | -------------------------------- | ---- | -------------------------------------------------------------------------- |
 | Coong App | `pnpm dev` (in `apps/coong`)     | 3000 | Requires `.env` — copy from `.env.e2e` for local dev without real Supabase |
-| Storybook | `pnpm dev:storybook` (from root) | 6006 | Component explorer for all Solid.js packages                               |
+| Storybook | `pnpm storybook:dev` (from root) | 6006 | Component explorer for all Solid.js packages                               |
 
 ### Key commands
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two minor inaccuracies in `AGENTS.md`:

- **pnpm version**: `10.26.1` → `10.33.2` (matches the `packageManager` field in `package.json`)
- **Storybook script name**: `pnpm dev:storybook` → `pnpm storybook:dev` (matches the actual script name in root `package.json`)

## Evidence of working environment

[Coong app running at localhost:3000](https://cursor.com/agents/bc-f8924dca-94b0-4317-bf31-cca64622454b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoong-app-screenshot.png)
[Storybook running at localhost:6006](https://cursor.com/agents/bc-f8924dca-94b0-4317-bf31-cca64622454b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook-new-window.png)
[Coong app after navigating to Musics page](https://cursor.com/agents/bc-f8924dca-94b0-4317-bf31-cca64622454b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter-tab-enter.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8924dca-94b0-4317-bf31-cca64622454b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8924dca-94b0-4317-bf31-cca64622454b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

