### PR TITLE
fix(utils): align subpath exports with CJS require resolution

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
     "dist/*"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "unpkg": "dist/index.global.js",
@@ -25,9 +25,13 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
-    "./*": "./*"
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "import": "./dist/*/index.mjs",
+      "require": "./dist/*/index.cjs"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/vite.config.mts
+++ b/packages/utils/vite.config.mts
@@ -1,1 +1,74 @@
-export {default} from '@winter-love/vite-lib-config/require'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {createConfig} from '@winter-love/vite-lib-config/index.mjs'
+import {defineConfig} from 'vite'
+
+const utilsRoot = path.dirname(fileURLToPath(import.meta.url))
+
+/** Entry chunks used only as barrel re-exports from the root index — Rollup must emit them for subpath exports. */
+const subpathBarrels = [
+  'match-run',
+  'number-to',
+  'pascal-case',
+  'path',
+  'prev-args',
+  'promise',
+  'request-Idle-callback',
+  'reverse',
+  'scroll-into-view',
+  'types',
+] as const
+
+const subpathEntries = Object.fromEntries(
+  subpathBarrels.map((name) => [
+    // Use "name/index" so output is dist/<name>/index.mjs (avoids clashing with dist/<name>/ chunks).
+    `${name}/index`,
+    path.join(utilsRoot, `src/${name}/index.ts`),
+  ]),
+)
+
+export default defineConfig((env) => {
+  const base = createConfig()(env)
+  const {rollupOptions} = base.build
+
+  return {
+    ...base,
+    build: {
+      ...base.build,
+      lib: {
+        ...base.build.lib,
+        entry: {
+          ...base.build.lib.entry,
+          ...subpathEntries,
+        },
+      },
+      rollupOptions: {
+        ...rollupOptions,
+        output: [
+          {
+            entryFileNames: '[name].mjs',
+            format: 'es',
+            preserveModules: true,
+            preserveModulesRoot: 'src',
+          },
+          {
+            entryFileNames(chunkInfo) {
+              const name = chunkInfo.name
+              if (name === 'index') {
+                return 'index.cjs'
+              }
+              if (name.endsWith('/index')) {
+                return `${name.slice(0, -'/index'.length)}/index.cjs`
+              }
+              return `${name}/index.cjs`
+            },
+            exports: 'named',
+            format: 'cjs',
+            preserveModules: true,
+            preserveModulesRoot: 'src',
+          },
+        ],
+      },
+    },
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes inconsistent `package.json` exports for `@winter-love/utils` subpaths so CommonJS `require('@winter-love/utils/<name>')` resolves to a CJS file (`.cjs`) instead of falling through to ESM (`.mjs`).

## Changes

- Replace the `"./*": "./*"` export with explicit `import` / `require` / `types` targets under `dist/*/index.*`.
- Set `main` to `dist/index.cjs` to match the Vite build output (the previous `dist/index.js` did not exist in the build).
- Update the utils Vite config: emit **preserve-modules** CJS for subpath chunks and add explicit barrel entries for modules that are only re-exported from the root `index` (e.g. `path`, `promise`, `types`) so `dist/<name>/index.mjs` and `dist/<name>/index.cjs` exist for wildcard exports.

## Verification

- `pnpm exec vitest run packages/utils` — all tests passed.
- `node -e "require('@winter-love/utils/path')"` from `apps/coong` — resolves to `dist/path/index.cjs` and loads successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d21e558f-bb07-40a3-bb3a-078daae3257e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d21e558f-bb07-40a3-bb3a-078daae3257e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

