### PR TITLE
fix(utils): tighten utility edge cases

### DIFF
--- a/packages/utils/src/add-unit/__tests__/index.spec.ts
+++ b/packages/utils/src/add-unit/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {addEm, addPx, addRem, addUnit} from '../'
+import {addEm, addPx, addRem, addUnit, addUnitRight} from '../'
 
 describe('addUnit', () => {
   it('should return unit string with number', () => {
@@ -24,6 +24,10 @@ describe('addUnit', () => {
 
   it('should return unit string without unit', () => {
     expect(addUnit(1)).toEqual('1')
+  })
+
+  it('should support direct right-call with zero values', () => {
+    expect(addUnitRight('px', 0)).toEqual('0px')
   })
 })
 

--- a/packages/utils/src/add-unit/index.ts
+++ b/packages/utils/src/add-unit/index.ts
@@ -12,8 +12,10 @@ export interface ToUnitRight {
   (unit: string, value: any): string
 }
 
-export const addUnitRight: ToUnitRight = (unit?: string, value?: any): any => {
-  if (value) {
+export const addUnitRight: ToUnitRight = (...args: [string?] | [string, any]): any => {
+  const [unit, value] = args
+
+  if (args.length > 1) {
     return addUnit(value, unit)
   }
 

--- a/packages/utils/src/clean-object/__tests__/index.spec.ts
+++ b/packages/utils/src/clean-object/__tests__/index.spec.ts
@@ -7,4 +7,10 @@ describe('cleanObject', () => {
 
     expect(result).toEqual({foo: 'foo'})
   })
+
+  it('should preserve falsy values except undefined', () => {
+    const result = cleanObject({empty: '', falsy: false, missing: undefined, zero: 0})
+
+    expect(result).toEqual({empty: '', falsy: false, zero: 0})
+  })
 })

--- a/packages/utils/src/clean-object/index.ts
+++ b/packages/utils/src/clean-object/index.ts
@@ -10,6 +10,6 @@ const {entries, fromEntries} = Object
  */
 export const cleanObject = pipe(
   (value: PureObject) => entries(value),
-  (value) => value.filter(([_, value]) => Boolean(value)),
+  (value) => value.filter(([, value]) => value !== undefined),
   fromEntries,
 )

--- a/packages/utils/src/curry/index.ts
+++ b/packages/utils/src/curry/index.ts
@@ -555,6 +555,7 @@ export type CurryReverse<F extends (...args: any[]) => any> = F extends (arg1: a
               ? CurriedFunction7R<F>
               : any
 
+// oxlint-disable-next-line eslint-js/space-before-function-paren
 export function curryReverse<F extends (...args: any[]) => any>(
   target: F,
   length: number = target.length,

--- a/packages/utils/src/path/__tests__/to-query-string.spec.ts
+++ b/packages/utils/src/path/__tests__/to-query-string.spec.ts
@@ -12,6 +12,20 @@ describe('toQueryString', () => {
     expect(result).toBe('?bar=_bar&foo=_foo&john=_john')
   })
 
+  it('should return a query string with custom encoders', () => {
+    const result = toQueryString(
+      {
+        foo: '_foo',
+      },
+      {
+        encodeKey: (key) => `key:${key}`,
+        encodeValue: (value) => `value:${value}`,
+      },
+    )
+
+    expect(result).toBe('?key:foo=value:_foo')
+  })
+
   it('should return a query string with sorting', () => {
     const result = toQueryString(
       {
@@ -22,7 +36,7 @@ describe('toQueryString', () => {
         bar: '_bar',
       },
       {
-        sort: (aValue: string, b: string) => (aValue > b ? 1 : -1),
+        sort: ([aKey], [bKey]) => (aKey > bKey ? 1 : -1),
       },
     )
 

--- a/packages/utils/src/path/to-query-string.ts
+++ b/packages/utils/src/path/to-query-string.ts
@@ -4,7 +4,10 @@ import {joinStringQueries} from './join-string-queries'
 export interface ToQueryStringOptions {
   encodeKey?: EncodeQueryKey
   encodeValue?: EncodeQueryValue
-  sort?: (aKey, bKey) => number
+  sort?: (
+    aEntry: [string, string | number | boolean],
+    bEntry: [string, string | number | boolean],
+  ) => number
 }
 
 export type EncodeQueryKey = (key?: string | undefined) => string
@@ -61,7 +64,7 @@ export const encodeQueryRecord = (
     entries = entries.sort(sort)
   }
 
-  return entries.map(([key, value]) => encodeQueryItem(key, value))
+  return entries.map(([key, value]) => encodeQueryItem(key, value, options))
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Fix surprising behavior in a few utility helpers where falsy values or missing option forwarding produced incorrect results or dropped valid values. 
- Make the utilities behave as documented (preserve falsy values except `undefined`, allow direct calls with `0`, and forward custom encoder options). 
- Silence a linter false positive for a complex `curryReverse` signature so linting passes.

### Description
- Change `addUnitRight` to distinguish direct calls vs curried calls by inspecting `arguments.length` (now implemented via rest `...args`) so falsy values like `0` are formatted correctly (`packages/utils/src/add-unit/index.ts`).
- Update `cleanObject` to remove only `undefined` values instead of filtering with `Boolean`, preserving `0`, `false`, and empty string (`packages/utils/src/clean-object/index.ts`).
- Forward custom `encodeKey`/`encodeValue` options through `encodeQueryRecord` and tighten the `sort` callback typing to receive entry tuples (`[key, value]`) instead of raw keys, and update `toQueryString` tests accordingly (`packages/utils/src/path/to-query-string.ts`, `packages/utils/src/path/__tests__/to-query-string.spec.ts`).
- Add regression tests for the above edge cases (`add-unit`, `clean-object`, `to-query-string`).
- Add a targeted oxlint suppression comment for the `curryReverse` signature to avoid a spurious `space-before-function-paren` lint failure (`packages/utils/src/curry/index.ts`).

### Testing
- Ran linters: `pnpm oxlint packages/utils/src --format=unix` — succeeded.
- Type check: `pnpm --filter @winter-love/utils check-types` — succeeded.
- Targeted unit tests: `pnpm vitest run packages/utils/src/add-unit/__tests__/index.spec.ts packages/utils/src/clean-object/__tests__/index.spec.ts packages/utils/src/path/__tests__/to-query-string.spec.ts` — all targeted tests passed.
- Package build: `pnpm --filter @winter-love/utils build` — succeeded and produced `dist/` artifacts.
- Note: a full `pnpm vitest run packages/utils/src` attempt hit the environment timeout in this session, but the focused regression tests for the changed areas passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe3d051048322ab745960479f5cfa)