### PR TITLE
chore: unify typecheck scripts and command docs

### DIFF
--- a/.cursor/commands/critical-review.md
+++ b/.cursor/commands/critical-review.md
@@ -1,0 +1,18 @@
+# Critical Review
+
+Review the target code for correctness risks and maintainability. When relevant, evaluate security, accessibility, and performance trade-offs using the same standards.
+
+## Scope
+
+- Perform the review within the **explicit scope** (files, PR diff, functions/modules, etc.). If a scope is provided, go deep only within that boundary.
+- If the **scope is empty or unclear, do not start reviewing**. Ask once more which files, commits, or features should be included.
+
+## Review Rules
+
+1. Minimize praise and formal agreement; focus on **observations, risks, and actionable alternatives**. If you judge that “this does not need to be fixed immediately,” include the rationale.
+2. Critique should be **evidence-based rigor**, not a harsh tone. For each claim, include at least one of: **code citation, reproduction path, or assumption**.
+3. Assign a **severity** to each issue. Example: **P0** (release/correctness/security blocker), **P1** (maintainability, bug risk, fix after alignment).
+4. Review from the perspective of a **developer who uses this code**. Evaluate API surface (names, types, props), misuse risk, and whether it is understandable without extra context.
+5. Check whether logic can be **decomposed and composed**. Call out mixed responsibilities and coupling that blocks testing or reuse.
+6. Inspect **cleanup and lifecycle handling** thoroughly: missing post-processing/cleanup, race conditions, and unmount scenarios around `useEffect` subscriptions, timers, event listeners, AbortController, etc.
+7. Include **example code** in improvement suggestions. **Prefer unified diffs when possible**, and group same-theme changes in **one diff**. For trivial one-line edits, an **inline code block** is enough.

--- a/.cursor/commands/new-pr.md
+++ b/.cursor/commands/new-pr.md
@@ -1,0 +1,19 @@
+# Create new pull request
+
+Create a new PR using the steps below.
+
+1. If the current branch is `dev`, create a `feature/<name>` branch.
+2. If there are uncommitted changes, commit them.
+3. Push the branch to the remote.
+4. Create a PR with `dev` as the base branch.
+
+If the current branch is not `dev`, use it as-is and run steps 2-4 above.
+
+Generate the PR title automatically based on the changes.
+
+If GitHub MCP is configured, create the PR. If it is not configured, stop the task.
+
+Include the following sections in the PR body:
+
+- Summary: Brief overview of the PR changes
+- Testing: How reviewers can verify the changes

--- a/.cursor/commands/update-pr.md
+++ b/.cursor/commands/update-pr.md
@@ -1,0 +1,3 @@
+# Update pull request
+
+If GitHub MCP is configured, update the PR body based on the latest changes. If it is not configured, stop the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This is a pnpm + Turborepo monorepo (`@winter-love/web`). The main app is **Coon
 - **Lint**: `pnpm lint` (runs `turbo lint` across all packages) — note: `@winter-love/utils` has pre-existing lint errors
 - **Test**: `pnpm test` (runs `vitest run` across all packages) — the full Vitest suite can legitimately take about 180 seconds to finish, so wait up to ~200 seconds before assuming it is hung or manually stopping it.
 - **Build packages**: `pnpm prepare` (runs `turbo build --filter=@winter-love/*`)
-- **Type check (Coong)**: `pnpm type-check` in `apps/coong`
+- **Type check (Coong)**: `pnpm typecheck` in `apps/coong`
 
 ### Gotchas
 

--- a/apps/cli-client/package.json
+++ b/apps/cli-client/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "lint": "cross-env NODE_ENV=script eslint src",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@solidjs/router": "catalog:",

--- a/apps/coong/README.md
+++ b/apps/coong/README.md
@@ -5,7 +5,7 @@
 - **Setup**
   - **`pnpm prepare`**: 설치/준비 단계에서 Supabase 타입 생성 실행
   - **`pnpm supabase:gen-types`**: Supabase 타입 생성
-  - **`pnpm type-check`**: TypeScript 타입 체크만 수행
+  - **`pnpm typecheck`**: TypeScript 타입 체크만 수행
 - **Dev**
   - **`pnpm dev`**: 개발 서버 실행
 - **Build**

--- a/apps/coong/package.json
+++ b/apps/coong/package.json
@@ -21,7 +21,7 @@
     "supabase:gen-types": "jiti scripts/gen-supabase-types.ts",
     "test:e2e": "playwright test",
     "test:e2e-ui": "playwright test --ui",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@lottiefiles/dotlottie-solid": "^0.5.15",

--- a/apps/hate-react/README.md
+++ b/apps/hate-react/README.md
@@ -41,4 +41,4 @@ Returns an empty message list if no token is provided.
 | `pnpm dev`        | Start development server |
 | `pnpm build`      | Production build         |
 | `pnpm lint`       | Run ESLint               |
-| `pnpm type-check` | TypeScript type check    |
+| `pnpm typecheck` | TypeScript type check    |

--- a/apps/hate-react/package.json
+++ b/apps/hate-react/package.json
@@ -8,7 +8,7 @@
     "dev": "vinxi dev",
     "lint": "cross-env NODE_ENV=script eslint src",
     "lint:fix": "cross-env NODE_ENV=script eslint src --fix",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@iconify-icon/solid": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "storybook:build": "storybook build",
-    "check-types": "turbo check-types",
+    "typecheck": "turbo typecheck",
     "chromatic": "nve 20.18.1 pnpm dlx chromatic --project-token=chpt_b4b4c6198bbdeda",
     "clean": "lerna clean --yes && pnpm dlx rimraf node_modules",
     "storybook:dev": "storybook dev -p 6006",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "vite build",
     "prepare": "vite build",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/solid-components/package.json
+++ b/packages/solid-components/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "node scripts/fix-build.js && rollup -c rollup.config.js && tspc -p tsconfig.build.json",
     "prepare": "pnpm run build",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "dev": "node scripts/fix-build.js && concurrently \"rollup -c rollup.config.js --watch\" \"tsc -p tsconfig.build.json --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/solid-use/package.json
+++ b/packages/solid-use/package.json
@@ -25,7 +25,7 @@
     "build": "vite build",
     "prepare": "vite build",
     "build:dev": "vite build --minify false",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "dev": "vite build --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "vite build",
     "prepare": "vite build",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/cli.js build -r 'test/assets' -a '**/*' ./node_modules/sw.js",
     "test": "vitest run"
   },

--- a/packages/tonejs-midi/package.json
+++ b/packages/tonejs-midi/package.json
@@ -26,7 +26,7 @@
     "build:dev": "vite build --minify false",
     "prepare": "pnpm run build",
     "build:ts": "tsc -p tsconfig.tone.json",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "prepare": "vite build",
     "dev": "vite build --watch --minify false"
   },

--- a/packages/vite-plugin-cdn/package.json
+++ b/packages/vite-plugin-cdn/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production vite build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@polka/url": "^0.5.0",

--- a/packages/vite-plugin-monorepo-alias/package.json
+++ b/packages/vite-plugin-monorepo-alias/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "check-types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "dev": "vite build --watch --minify false",
     "prepare": "vite build",
     "preview": "vite build -c vite.preview.config.mts",

--- a/turbo.json
+++ b/turbo.json
@@ -21,8 +21,8 @@
       "cache": false,
       "persistent": true
     },
-    "check-types": {
-      "dependsOn": ["^check-types"],
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"]
     },
     "lint": {

--- a/turbo/generators/templates/package.hbs
+++ b/turbo/generators/templates/package.hbs
@@ -2,5 +2,5 @@
 "repository": { "type": "git", "url": "https://github.com/bichikim/web.git" }, "exports": { ".": {
 "import": "./dist/index.mjs" }, "./*": "./*" }, "main": "dist/index.js", "types": "dist/index.d.ts",
 "files": [ "dist/*" ], "scripts": { "build": "cross-env NODE_ENV=production vite build", "test":
-"echo \"Error: no test specified\" && exit 1", "type-check": "tsc --noEmit" }, "dependencies": {
+"echo \"Error: no test specified\" && exit 1", "typecheck": "tsc --noEmit" }, "dependencies": {
 "solid-js": "^1.8" }, "devDependencies": { "@{{scope}}/vite-lib-config": "workspace:*" } }


### PR DESCRIPTION
## Summary
- workspace 전반의 `check-types`/`type-check` 스크립트를 `typecheck`로 통일했습니다.
- 루트 `package.json`과 `turbo.json`의 타입체크 태스크명을 일관되게 맞췄습니다.
- `.cursor/commands`에 PR 생성/업데이트 및 크리티컬 리뷰 커맨드 템플릿을 추가했습니다.

## Testing
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Made with [Cursor](https://cursor.com)