### PR TITLE
fix(packages): address package review bugs

### DIFF
--- a/packages/solid-test/package.json
+++ b/packages/solid-test/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "build": "vite build",
     "prepare": "vite build",
-    "lint": "cross-env NODE_ENV=script eslint src",
-    "lint:fix": "cross-env NODE_ENV=script eslint src --fix",
+    "lint": "oxlint src",
+    "lint:fix": "oxlint src --fix",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/solid-use/src/animation-loop/index.spec.ts
+++ b/packages/solid-use/src/animation-loop/index.spec.ts
@@ -43,8 +43,11 @@ describe('useAnimationLoop', () => {
     expect(requestAnimationFrame).toHaveBeenCalled()
     expect(callback).not.toHaveBeenCalled()
     expect(animationTrigger.changed).toBe(1)
-    animationTrigger.run()
+    const timestamp = 123.45
+
+    animationTrigger.target?.(timestamp)
     expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(timestamp)
     expect(animationTrigger.changed).toBe(2)
   })
 

--- a/packages/solid-use/src/animation-loop/index.ts
+++ b/packages/solid-use/src/animation-loop/index.ts
@@ -11,8 +11,8 @@ export const useAnimationLoop = createUseLoop<{__never__?: never}, [DOMHighResTi
   }
 
   const start = (callback: (...args: any) => void) => {
-    flag = requestAnimationFrame(() => {
-      callback()
+    flag = requestAnimationFrame((timestamp) => {
+      callback(timestamp)
       start(callback)
     })
   }

--- a/packages/solid-use/src/event/index.spec.ts
+++ b/packages/solid-use/src/event/index.spec.ts
@@ -45,6 +45,7 @@ describe('onEvent', () => {
     const target = document.createElement('div')
 
     vi.spyOn(target, 'addEventListener')
+    vi.spyOn(target, 'removeEventListener')
 
     const callback = vi.fn()
     const options = {capture: true, passive: true}
@@ -58,5 +59,6 @@ describe('onEvent', () => {
     await flushPromises()
     expect(target.addEventListener).toHaveBeenCalledWith('click', expect.any(Function), options)
     dispose()
+    expect(target.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function), options)
   })
 })

--- a/packages/solid-use/src/event/index.ts
+++ b/packages/solid-use/src/event/index.ts
@@ -6,7 +6,7 @@ import {createEffect, onCleanup} from 'solid-js'
 export interface Emitter {
   addEventListener(type: string, listener: EventListener, options?: AddEventListenerOptions): void
 
-  removeEventListener(type: string, listener: EventListener): void
+  removeEventListener(type: string, listener: EventListener, options?: EventListenerOptions): void
 }
 
 export interface OnEvent {
@@ -50,7 +50,7 @@ export const useEvent: OnEvent = (
     element?.addEventListener(type, listener, options)
 
     onCleanup(() => {
-      element?.removeEventListener(type, listener)
+      element?.removeEventListener(type, listener, options)
     })
 
     return element

--- a/packages/vite-plugin-cdn/package.json
+++ b/packages/vite-plugin-cdn/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@types/node-fetch": "^2.6.13",
     "@winter-love/vite-lib-config": "workspace:*",
+    "cross-env": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,6 +975,9 @@ importers:
       '@winter-love/vite-lib-config':
         specifier: workspace:*
         version: link:../vite-lib-config
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
       vite:
         specifier: 'catalog:'
         version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)


### PR DESCRIPTION
### Motivation
- Tests and package tasks were failing due to mismatched event cleanup options, missing `requestAnimationFrame` timestamp propagation, and package script/dependency inconsistencies that prevented package-local lint/build runs.

### Description
- Forward the `DOMHighResTimeStamp` from `requestAnimationFrame` through `useAnimationLoop` and update the test to assert the timestamp is passed to the callback by calling the mocked frame handler with a timestamp.
- Ensure `useEvent` calls `removeEventListener` with the same `options` used for `addEventListener` and extend the tests to assert the listener is removed with those options.
- Change `@winter-love/solid-test` lint scripts from `cross-env NODE_ENV=script eslint src` to `oxlint src` so package-local linting uses the repo lint tool.
- Add `cross-env` as a devDependency to `@winter-love/vite-plugin-cdn` and update the lockfile so the package `build` script can run standalone.

### Testing
- Ran `pnpm install --offline --ignore-scripts`, which completed successfully.
- Ran the focused Vitest suite `pnpm vitest run packages/solid-use/src/animation-loop/index.spec.ts packages/solid-use/src/event/index.spec.ts --reporter=dot`, which passed (`2 files, 7 tests`).
- Ran `pnpm --filter @winter-love/solid-test lint` and `pnpm --filter @winter-love/vite-plugin-cdn build`, both of which succeeded.
- Ran workspace typecheck with `pnpm --filter './packages/*' typecheck` and the package build `pnpm --filter './packages/*' build`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c8d95dc48322ba99fb46ca7d73f7)