### PR TITLE
Add git-backed secret-vault CLI package

### DIFF
--- a/packages/secret-vault/README.md
+++ b/packages/secret-vault/README.md
@@ -1,0 +1,244 @@
+# Secret Vault
+
+Private git-backed environment secret vault CLI.
+
+`secret-vault` stores secrets in a private GitHub repository at:
+
+```text
+<namespace>/vault.json
+```
+
+Encrypted storage is the default. Plain storage is available only when explicitly configured.
+
+## Install
+
+This package is part of the workspace:
+
+```sh
+pnpm --filter @winter-love/secret-vault build
+```
+
+CLI binary:
+
+```sh
+secret-vault
+```
+
+## Config
+
+Default config path:
+
+```text
+.secret-vault.json
+```
+
+Override:
+
+```sh
+secret-vault --config ./custom-secret-vault.json list
+```
+
+Example:
+
+```json
+{
+  "repository": "git@github.com:owner/private-secret-vault.git",
+  "namespace": "my-app",
+  "exportPath": ".env.local",
+  "storage": "encrypted"
+}
+```
+
+Fields:
+
+- `repository`: private vault repository URL.
+- `namespace`: optional. If missing, the current project git remote URL is used.
+- `exportPath`: optional. Defaults to `.env.local`. Used by `sync`.
+- `storage`: optional. Defaults to `encrypted`; use `plain` only when you intentionally want plaintext.
+
+`vaultPath` is not supported. The layout is always `<namespace>/vault.json`.
+
+## Storage Layout
+
+`namespace` is a folder name inside the vault repository, not a local project path. One vault repo can hold secrets for multiple projects:
+
+```text
+private-secret-vault/          # repository in config
+  my-app/
+    vault.json                 # namespace "my-app"
+  other-app/
+    vault.json                 # another project
+```
+
+If `namespace` is omitted, the current project's `origin` remote is normalized and used instead. For `git@github.com:owner/my-app.git`:
+
+```text
+private-secret-vault/
+  git-github.com-owner-my-app/
+    vault.json
+```
+
+After `secret-vault add FOO=bar` and `secret-vault add TOKEN=secret`, `my-app/vault.json` in the vault repo looks like this.
+
+Encrypted (default) — keys and values live inside `ciphertext`; only crypto metadata is visible in git:
+
+```json
+{
+  "version": 1,
+  "storage": "encrypted",
+  "kdf": "scrypt",
+  "salt": "a1b2c3...",
+  "scryptParams": {"N": 16384, "r": 8, "p": 1},
+  "iv": "d4e5f6...",
+  "authTag": "789abc...",
+  "ciphertext": "def012..."
+}
+```
+
+Plain (only when `"storage": "plain"`) — values are readable in the repository:
+
+```json
+{
+  "version": 1,
+  "storage": "plain",
+  "values": {
+    "FOO": "bar",
+    "TOKEN": "secret"
+  }
+}
+```
+
+On the application side, `.secret-vault.json` only points at the vault repo. Secrets are copied into the project with `export`:
+
+```text
+my-app/                        # application repo (where you run the CLI)
+  .secret-vault.json           # repository + namespace; no passphrase or secrets
+  .env.local                   # created by `secret-vault export --out .env.local`
+```
+
+## Create Config
+
+Use an existing private repository:
+
+```sh
+secret-vault init --repository git@github.com:owner/private-secret-vault.git
+```
+
+Create a new private GitHub repository through `gh`:
+
+```sh
+secret-vault init --create-repo owner/private-secret-vault
+```
+
+Or create/save repository config directly:
+
+```sh
+secret-vault repo create owner/private-secret-vault
+```
+
+The GitHub flow uses `gh auth status`, `gh auth login`, and `gh repo create`.
+
+## Add And Modify
+
+Quick assignment:
+
+```sh
+secret-vault add FOO=bar
+secret-vault modify FOO=new-value
+```
+
+Value option:
+
+```sh
+secret-vault add FOO --value "hello world"
+secret-vault modify TOKEN --value "a=b=c"
+```
+
+stdin value:
+
+```sh
+printf '%s' "$TOKEN" | secret-vault add TOKEN --stdin
+cat private-key.pem | secret-vault modify PRIVATE_KEY --stdin
+```
+
+Prompt value:
+
+```sh
+secret-vault add FOO
+secret-vault modify FOO
+```
+
+`add` asks before overwriting an existing key. `modify` asks before creating a missing key.
+
+## Import And Export
+
+Import dotenv values:
+
+```sh
+secret-vault import .env.local
+cat .env.production | secret-vault import --stdin
+```
+
+Export dotenv values:
+
+```sh
+secret-vault export
+secret-vault export --out .env.local
+```
+
+Sync vault secrets into the configured env file:
+
+```sh
+secret-vault sync
+secret-vault sync --out .env.staging
+```
+
+Packages without `.secret-vault.json` skip `sync` silently. In a monorepo, run it recursively:
+
+```sh
+pnpm -r exec secret-vault sync
+```
+
+Or add a package script where needed:
+
+```json
+{
+  "scripts": {
+    "env:sync": "secret-vault sync"
+  }
+}
+```
+
+`list` prints keys only:
+
+```sh
+secret-vault list
+```
+
+## Encryption
+
+Encrypted vaults use Node `crypto`:
+
+- passphrase-derived key with `scrypt`
+- `AES-256-GCM` encrypted payload
+- stored metadata: `version`, `kdf`, `salt`, `iv`, `authTag`, `ciphertext`
+
+Passphrase sources:
+
+```sh
+secret-vault add FOO=bar
+SECRET_VAULT_PASSPHRASE=... secret-vault --passphrase-env export
+printf '%s' "$SECRET_VAULT_PASSPHRASE" | secret-vault --passphrase-stdin export
+```
+
+The passphrase is never written to `.secret-vault.json` or the vault repository.
+
+## Repository Sync
+
+The CLI clones or updates the configured vault repository in a local cache, writes the namespace vault file, commits, and pushes.
+
+Commit message format:
+
+```text
+Update secret vault namespace <namespace>
+```

--- a/packages/secret-vault/bin/index.js
+++ b/packages/secret-vault/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import('../dist/cli.mjs')

--- a/packages/secret-vault/package.json
+++ b/packages/secret-vault/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@winter-love/secret-vault",
+  "version": "0.1.0",
+  "description": "Private git-backed secret vault CLI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bichikim/web.git"
+  },
+  "bin": {
+    "secret-vault": "bin/index.js"
+  },
+  "files": [
+    "bin/*",
+    "dist/*"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./*": "./*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite build",
+    "prepare": "vite build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "commander": "^14.0.3",
+    "execa": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@winter-love/vite-lib-config": "workspace:*",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-dts": "catalog:",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/secret-vault/src/__tests__/commands.spec.ts
+++ b/packages/secret-vault/src/__tests__/commands.spec.ts
@@ -1,0 +1,478 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {addSecret, importSecrets, modifySecret, syncSecrets} from '../commands'
+import {getVaultFilePath, writeVaultValues} from '../vault'
+import type {CommandRunner, Prompt} from '../types'
+
+const createRunner = (repoPath: string): CommandRunner => {
+  return async (file, args) => {
+    if (file === 'git' && args[0] === 'remote') {
+      return {
+        stderr: '',
+        stdout: 'git@github.com:owner/app.git',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'pull') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'checkout') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'merge') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'add') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'diff') {
+      return {
+        stderr: '',
+        stdout: `${args[args.length - 1] ?? 'vault.json'}\n`,
+      }
+    }
+
+    if (file === 'git' && args[0] === 'commit') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'git' && args[0] === 'push') {
+      return {
+        stderr: '',
+        stdout: '',
+      }
+    }
+
+    if (file === 'gh') {
+      return {
+        stderr: '',
+        stdout: 'PRIVATE',
+      }
+    }
+
+    throw new Error(`Unexpected command: ${file} ${args.join(' ')} at ${repoPath}`)
+  }
+}
+
+const createPrompt = (confirm: boolean = true): Prompt => {
+  return {
+    confirm: async () => confirm,
+    passphrase: async () => 'passphrase',
+    value: async () => 'prompt-value',
+  }
+}
+
+const createProject = async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-command-'))
+  const repoPath = path.join(tmpDir, 'repo')
+  const configPath = path.join(tmpDir, '.secret-vault.json')
+  const vaultPath = getVaultFilePath(repoPath, 'app')
+
+  await fs.promises.mkdir(path.join(repoPath, '.git'), {recursive: true})
+  await fs.promises.writeFile(
+    configPath,
+    JSON.stringify({
+      namespace: 'app',
+      repository: 'git@github.com:owner/vault.git',
+      storage: 'plain',
+    }),
+    'utf8',
+  )
+
+  return {
+    configPath,
+    repoPath,
+    tmpDir,
+    vaultPath,
+  }
+}
+
+describe('commands', () => {
+  it('should ask before overwriting existing add key', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    await writeVaultValues(vaultPath, 'plain', {foo: 'old'}, undefined)
+
+    try {
+      await expect(
+        addSecret('foo=new', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(false),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toBe(false)
+      await expect(readFileValue(vaultPath, 'foo')).resolves.toBe('old')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should ask before creating missing modify key', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    await writeVaultValues(vaultPath, 'plain', {}, undefined)
+
+    try {
+      await expect(
+        modifySecret('foo=new', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toBe(true)
+      await expect(readFileValue(vaultPath, 'foo')).resolves.toBe('new')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should not create missing modify key when confirm is declined', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    await writeVaultValues(vaultPath, 'plain', {}, undefined)
+
+    try {
+      await expect(
+        modifySecret('foo=new', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(false),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toBe(false)
+      expect(await readFileValue(vaultPath, 'foo')).toBeUndefined()
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should add secret from value option', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+
+    try {
+      await expect(
+        addSecret('foo', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+          value: 'from-option',
+        }),
+      ).resolves.toBe(true)
+      await expect(readFileValue(vaultPath, 'foo')).resolves.toBe('from-option')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should use cli namespace override', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const stagingVaultPath = getVaultFilePath(repoPath, 'staging')
+
+    try {
+      await expect(
+        addSecret('foo', {
+          configPath,
+          cwd: tmpDir,
+          namespace: 'staging',
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+          value: 'staging-value',
+        }),
+      ).resolves.toBe(true)
+      await expect(readFileValue(stagingVaultPath, 'foo')).resolves.toBe('staging-value')
+      await expect(fs.promises.stat(vaultPath)).rejects.toMatchObject({code: 'ENOENT'})
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should modify secret from stdin option', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    await writeVaultValues(vaultPath, 'plain', {foo: 'old'}, undefined)
+
+    try {
+      await expect(
+        modifySecret('foo', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          readStdin: async () => 'from-stdin',
+          repoPath,
+          runner: createRunner(repoPath),
+          stdin: true,
+        }),
+      ).resolves.toBe(true)
+      await expect(readFileValue(vaultPath, 'foo')).resolves.toBe('from-stdin')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should add secret from value prompt when no assignment value source exists', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+
+    try {
+      await expect(
+        addSecret('foo', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toBe(true)
+      await expect(readFileValue(vaultPath, 'foo')).resolves.toBe('prompt-value')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should reject multiple value sources', async () => {
+    const {configPath, repoPath, tmpDir} = await createProject()
+
+    try {
+      await expect(
+        addSecret('foo=bar', {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+          value: 'from-option',
+        }),
+      ).rejects.toThrow('Use KEY=VALUE or KEY with --value/--stdin, not both')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should import secrets from dotenv file', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const envPath = path.join(tmpDir, '.env.local')
+
+    await fs.promises.writeFile(envPath, 'FOO=bar\n# comment\nTOKEN="a=b"\n', 'utf8')
+
+    try {
+      await expect(
+        importSecrets(envPath, {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toEqual(['FOO', 'TOKEN'])
+      await expect(readFileValue(vaultPath, 'FOO')).resolves.toBe('bar')
+      await expect(readFileValue(vaultPath, 'TOKEN')).resolves.toBe('a=b')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should import secrets from stdin', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+
+    try {
+      await expect(
+        importSecrets(undefined, {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          readStdin: async () => 'FOO=bar',
+          repoPath,
+          runner: createRunner(repoPath),
+          stdin: true,
+        }),
+      ).resolves.toEqual(['FOO'])
+      await expect(readFileValue(vaultPath, 'FOO')).resolves.toBe('bar')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should reject import that overwrites existing keys by default', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const envPath = path.join(tmpDir, '.env.local')
+
+    await writeVaultValues(vaultPath, 'plain', {FOO: 'old'}, undefined)
+    await fs.promises.writeFile(envPath, 'FOO=new\nBAR=baz\n', 'utf8')
+
+    try {
+      await expect(
+        importSecrets(envPath, {
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).rejects.toThrow('Import would overwrite existing keys: FOO')
+      await expect(readFileValue(vaultPath, 'FOO')).resolves.toBe('old')
+      expect(await readFileValue(vaultPath, 'BAR')).toBeUndefined()
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should import with confirm-overwrite when overwrite is confirmed', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const envPath = path.join(tmpDir, '.env.local')
+
+    await writeVaultValues(vaultPath, 'plain', {FOO: 'old'}, undefined)
+    await fs.promises.writeFile(envPath, 'FOO=new\nBAR=baz\n', 'utf8')
+
+    try {
+      await expect(
+        importSecrets(envPath, {
+          configPath,
+          confirmOverwrite: true,
+          cwd: tmpDir,
+          prompt: createPrompt(true),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toEqual(['BAR', 'FOO'])
+      await expect(readFileValue(vaultPath, 'FOO')).resolves.toBe('new')
+      await expect(readFileValue(vaultPath, 'BAR')).resolves.toBe('baz')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should skip import when confirm-overwrite is declined', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const envPath = path.join(tmpDir, '.env.local')
+
+    await writeVaultValues(vaultPath, 'plain', {FOO: 'old'}, undefined)
+    await fs.promises.writeFile(envPath, 'FOO=new\n', 'utf8')
+
+    try {
+      await expect(
+        importSecrets(envPath, {
+          configPath,
+          confirmOverwrite: true,
+          cwd: tmpDir,
+          prompt: createPrompt(false),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toEqual([])
+      await expect(readFileValue(vaultPath, 'FOO')).resolves.toBe('old')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should sync secrets to default export path', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    await writeVaultValues(vaultPath, 'plain', {FOO: 'bar'}, undefined)
+    const exportPath = path.join(tmpDir, '.env.local')
+
+    try {
+      await expect(
+        syncSecrets({
+          configPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toEqual({
+        exportPath,
+        keyCount: 1,
+        skipped: false,
+      })
+      await expect(fs.promises.readFile(exportPath, 'utf8')).resolves.toBe('FOO="bar"\n')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should sync secrets to configured export path', async () => {
+    const {configPath, repoPath, tmpDir, vaultPath} = await createProject()
+    const customConfigPath = path.join(tmpDir, 'custom.secret-vault.json')
+
+    await fs.promises.writeFile(
+      customConfigPath,
+      JSON.stringify({
+        exportPath: '.env.staging',
+        namespace: 'app',
+        repository: 'git@github.com:owner/vault.git',
+        storage: 'plain',
+      }),
+      'utf8',
+    )
+    await writeVaultValues(vaultPath, 'plain', {TOKEN: 'secret'}, undefined)
+    const exportPath = path.join(tmpDir, '.env.staging')
+
+    try {
+      await expect(
+        syncSecrets({
+          configPath: customConfigPath,
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          repoPath,
+          runner: createRunner(repoPath),
+        }),
+      ).resolves.toEqual({
+        exportPath,
+        keyCount: 1,
+        skipped: false,
+      })
+      await expect(fs.promises.readFile(exportPath, 'utf8')).resolves.toBe('TOKEN="secret"\n')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should skip sync when config is missing', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-sync-skip-'))
+
+    try {
+      await expect(
+        syncSecrets({
+          configPath: path.join(tmpDir, 'missing.secret-vault.json'),
+          cwd: tmpDir,
+          prompt: createPrompt(),
+          runner: createRunner(path.join(tmpDir, 'repo')),
+        }),
+      ).resolves.toEqual({skipped: true})
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+})
+
+const readFileValue = async (vaultPath: string, key: string) => {
+  const content = JSON.parse(await fs.promises.readFile(vaultPath, 'utf8')) as {
+    values: Record<string, string>
+  }
+
+  return content.values[key]
+}

--- a/packages/secret-vault/src/__tests__/config.spec.ts
+++ b/packages/secret-vault/src/__tests__/config.spec.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {loadConfig, parseConfig, resolveConfigPath} from '../config'
+
+describe('config', () => {
+  it('should resolve default config path from cwd', () => {
+    expect(resolveConfigPath({cwd: '/tmp/project'})).toBe('/tmp/project/.secret-vault.json')
+  })
+
+  it('should load config from override path', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-config-'))
+    const configPath = path.join(tmpDir, 'custom.json')
+
+    await fs.promises.writeFile(
+      configPath,
+      JSON.stringify({
+        namespace: 'app',
+        repository: 'git@github.com:owner/vault.git',
+        storage: 'plain',
+      }),
+      'utf8',
+    )
+
+    try {
+      await expect(loadConfig({configPath, cwd: tmpDir})).resolves.toEqual({
+        configPath,
+        exportPath: '.env.local',
+        namespace: 'app',
+        repository: 'git@github.com:owner/vault.git',
+        storage: 'plain',
+      })
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should default storage to encrypted', () => {
+    expect(parseConfig({repository: 'git@github.com:owner/vault.git'})).toEqual({
+      exportPath: undefined,
+      repository: 'git@github.com:owner/vault.git',
+      storage: undefined,
+    })
+  })
+
+  it('should reject vaultPath config', () => {
+    expect(() =>
+      parseConfig({
+        repository: 'git@github.com:owner/vault.git',
+        vaultPath: 'vault.json',
+      }),
+    ).toThrow('vaultPath is not supported')
+  })
+
+  it('should reject invalid config json', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-config-invalid-'))
+    const configPath = path.join(tmpDir, 'broken.json')
+
+    await fs.promises.writeFile(configPath, '{not-json', 'utf8')
+
+    try {
+      await expect(loadConfig({configPath, cwd: tmpDir})).rejects.toThrow(
+        `Config file ${configPath} is not valid JSON`,
+      )
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should reject missing config file', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-config-missing-'))
+    const configPath = path.join(tmpDir, 'missing.json')
+
+    try {
+      await expect(loadConfig({configPath, cwd: tmpDir})).rejects.toThrow(
+        `Config file not found: ${configPath}`,
+      )
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+})

--- a/packages/secret-vault/src/__tests__/git.spec.ts
+++ b/packages/secret-vault/src/__tests__/git.spec.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {commitAndPush} from '../git'
+import {writeVaultValues} from '../vault'
+import type {CommandRunner, Prompt} from '../types'
+
+class MockCommandError extends Error {
+  constructor(
+    message: string,
+    readonly stdout: string,
+    readonly stderr: string,
+  ) {
+    super(message)
+  }
+}
+
+const createPrompt = (confirm: boolean): Prompt => ({
+  confirm: async () => confirm,
+  passphrase: async () => 'passphrase',
+  value: async () => 'value',
+})
+
+const createProject = async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-git-'))
+  const repoPath = path.join(tmpDir, 'repo')
+  const vaultPath = path.join(repoPath, 'app', 'vault.json')
+
+  await fs.promises.mkdir(path.join(repoPath, '.git'), {recursive: true})
+  await writeVaultValues(vaultPath, 'plain', {foo: 'bar'}, undefined)
+
+  return {
+    repoPath,
+    tmpDir,
+    vaultPath,
+  }
+}
+
+describe('commitAndPush', () => {
+  it('should pull with merge before push', async () => {
+    const {repoPath, tmpDir, vaultPath} = await createProject()
+    const commands: string[] = []
+
+    const runner: CommandRunner = async (file, args) => {
+      commands.push(`${file} ${args.join(' ')}`)
+
+      if (file === 'git' && args[0] === 'diff') {
+        return {stderr: '', stdout: 'app/vault.json\n'}
+      }
+
+      return {stderr: '', stdout: ''}
+    }
+
+    try {
+      await expect(
+        commitAndPush({prompt: createPrompt(true), runner}, repoPath, 'app', vaultPath),
+      ).resolves.toBe(true)
+
+      const pullIndex = commands.findIndex((command) => command.includes('pull --no-rebase'))
+      const pushIndex = commands.findIndex((command) => command === 'git push')
+
+      expect(pullIndex).toBeGreaterThan(-1)
+      expect(pushIndex).toBeGreaterThan(pullIndex)
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should resolve merge conflict when overwrite is confirmed', async () => {
+    const {repoPath, tmpDir, vaultPath} = await createProject()
+    const localContent = await fs.promises.readFile(vaultPath, 'utf8')
+    const commands: string[] = []
+
+    const runner: CommandRunner = async (file, args) => {
+      commands.push(`${file} ${args.join(' ')}`)
+
+      if (file === 'git' && args[0] === 'diff') {
+        return {stderr: '', stdout: 'app/vault.json\n'}
+      }
+
+      if (file === 'git' && args[0] === 'pull') {
+        await fs.promises.writeFile(path.join(repoPath, '.git', 'MERGE_HEAD'), 'deadbeef\n', 'utf8')
+        throw new MockCommandError(
+          'git pull failed',
+          '',
+          'CONFLICT (content): Merge conflict in app/vault.json',
+        )
+      }
+
+      return {stderr: '', stdout: ''}
+    }
+
+    try {
+      await expect(
+        commitAndPush({prompt: createPrompt(true), runner}, repoPath, 'app', vaultPath),
+      ).resolves.toBe(true)
+
+      expect(commands).toContain('git checkout --ours -- app/vault.json')
+      expect(commands).toContain('git commit --no-edit')
+      expect(await fs.promises.readFile(vaultPath, 'utf8')).toBe(localContent)
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should abort merge and guide manual resolution when overwrite is declined', async () => {
+    const {repoPath, tmpDir, vaultPath} = await createProject()
+    const commands: string[] = []
+
+    const runner: CommandRunner = async (file, args) => {
+      commands.push(`${file} ${args.join(' ')}`)
+
+      if (file === 'git' && args[0] === 'diff') {
+        return {stderr: '', stdout: 'app/vault.json\n'}
+      }
+
+      if (file === 'git' && args[0] === 'pull') {
+        await fs.promises.writeFile(path.join(repoPath, '.git', 'MERGE_HEAD'), 'deadbeef\n', 'utf8')
+        throw new MockCommandError(
+          'git pull failed',
+          '',
+          'CONFLICT (content): Merge conflict in app/vault.json',
+        )
+      }
+
+      return {stderr: '', stdout: ''}
+    }
+
+    try {
+      await expect(
+        commitAndPush({prompt: createPrompt(false), runner}, repoPath, 'app', vaultPath),
+      ).rejects.toThrow('Vault push cancelled due to a merge conflict.')
+
+      expect(commands).toContain('git merge --abort')
+      expect(commands.some((command) => command === 'git push')).toBe(false)
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+})

--- a/packages/secret-vault/src/__tests__/key-value.spec.ts
+++ b/packages/secret-vault/src/__tests__/key-value.spec.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+import {formatDotenv, parseAssignment, parseDotenv, parseKey} from '../key-value'
+
+describe('key-value', () => {
+  it('should parse simple assignment', () => {
+    expect(parseAssignment('foo=dddd')).toEqual({
+      key: 'foo',
+      value: 'dddd',
+    })
+  })
+
+  it('should parse quoted key and value', () => {
+    expect(parseAssignment('"foo"="dddd"')).toEqual({
+      key: 'foo',
+      value: 'dddd',
+    })
+  })
+
+  it('should keep equal signs inside value', () => {
+    expect(parseAssignment('token=a=b=c')).toEqual({
+      key: 'token',
+      value: 'a=b=c',
+    })
+  })
+
+  it('should reject assignment without separator', () => {
+    expect(() => parseAssignment('foo')).toThrow('Expected KEY=VALUE')
+  })
+
+  it('should parse standalone key', () => {
+    expect(parseKey('"foo"')).toBe('foo')
+  })
+
+  it('should reject standalone key with separator', () => {
+    expect(() => parseKey('foo=bar')).toThrow('Secret key must not contain "="')
+  })
+
+  it('should parse dotenv content', () => {
+    expect(parseDotenv('FOO=bar\n# comment\nTOKEN="a=b"\n')).toEqual({
+      FOO: 'bar',
+      TOKEN: 'a=b',
+    })
+  })
+
+  it('should format dotenv output sorted by key', () => {
+    expect(formatDotenv({a: 'one', b: 'two words'})).toBe('a="one"\nb="two words"')
+  })
+})

--- a/packages/secret-vault/src/__tests__/namespace.spec.ts
+++ b/packages/secret-vault/src/__tests__/namespace.spec.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from 'vitest'
+import {normalizeNamespace, resolveNamespace} from '../namespace'
+import type {CommandRunner} from '../types'
+
+describe('namespace', () => {
+  it('should convert namespace to filesystem-safe value', () => {
+    expect(normalizeNamespace('git@github.com:owner/private-secret-vault.git')).toBe(
+      'git-github.com-owner-private-secret-vault',
+    )
+  })
+
+  it('should reject reserved namespaces', () => {
+    expect(() => normalizeNamespace('.')).toThrow(
+      'Namespace must be a single filesystem-safe path segment',
+    )
+    expect(() => normalizeNamespace('..')).toThrow(
+      'Namespace must be a single filesystem-safe path segment',
+    )
+  })
+
+  it('should use config namespace before git remote', async () => {
+    const runner: CommandRunner = async () => {
+      throw new Error('runner should not be called')
+    }
+
+    await expect(
+      resolveNamespace({
+        configNamespace: 'my app',
+        cwd: '/tmp/project',
+        runner,
+      }),
+    ).resolves.toBe('my-app')
+  })
+
+  it('should prefer cli namespace over config namespace', async () => {
+    const runner: CommandRunner = async () => {
+      throw new Error('runner should not be called')
+    }
+
+    await expect(
+      resolveNamespace({
+        cliNamespace: 'cli app',
+        configNamespace: 'config-app',
+        cwd: '/tmp/project',
+        runner,
+      }),
+    ).resolves.toBe('cli-app')
+  })
+
+  it('should fallback to git remote origin', async () => {
+    const runner: CommandRunner = async (file, args) => {
+      expect(file).toBe('git')
+      expect(args).toEqual(['remote', 'get-url', 'origin'])
+
+      return {
+        stderr: '',
+        stdout: 'git@github.com:owner/app.git',
+      }
+    }
+
+    await expect(
+      resolveNamespace({
+        cwd: '/tmp/project',
+        runner,
+      }),
+    ).resolves.toBe('git-github.com-owner-app')
+  })
+})

--- a/packages/secret-vault/src/__tests__/process.spec.ts
+++ b/packages/secret-vault/src/__tests__/process.spec.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it, vi} from 'vitest'
+import {SecretVaultError} from '../errors'
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}))
+
+import {execa} from 'execa'
+import {runCommand} from '../process'
+
+describe('runCommand', () => {
+  it('should wrap command failures in SecretVaultError', async () => {
+    vi.mocked(execa).mockRejectedValue({
+      message: 'Command failed with exit code 1',
+      stderr: 'fatal: not a git repository',
+      stdout: '',
+    })
+
+    await expect(runCommand('git', ['status'], {cwd: '/tmp/repo'})).rejects.toThrow(
+      SecretVaultError,
+    )
+    await expect(runCommand('git', ['status'], {cwd: '/tmp/repo'})).rejects.toThrow(
+      'Command failed (git status)',
+    )
+    await expect(runCommand('git', ['status'], {cwd: '/tmp/repo'})).rejects.toThrow(
+      'fatal: not a git repository',
+    )
+  })
+})

--- a/packages/secret-vault/src/__tests__/prompt.spec.ts
+++ b/packages/secret-vault/src/__tests__/prompt.spec.ts
@@ -1,0 +1,38 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import * as prompt from '../prompt'
+
+describe('readPassphrase', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('should read passphrase from env when passphraseEnv is enabled', async () => {
+    vi.stubEnv('SECRET_VAULT_PASSPHRASE', 'from-env')
+
+    await expect(prompt.readPassphrase({passphraseEnv: true})).resolves.toBe('from-env')
+  })
+
+  it('should ignore env when passphraseEnv is not enabled', async () => {
+    vi.stubEnv('SECRET_VAULT_PASSPHRASE', 'from-env')
+
+    await expect(
+      prompt.readPassphrase({
+        passphraseStdin: true,
+        readStdin: async () => 'from-stdin',
+      }),
+    ).resolves.toBe('from-stdin')
+  })
+
+  it('should reject passphraseEnv when env is missing', async () => {
+    await expect(prompt.readPassphrase({passphraseEnv: true})).rejects.toThrow(
+      'SECRET_VAULT_PASSPHRASE is not set',
+    )
+  })
+
+  it('should reject using passphrase stdin and env together', async () => {
+    await expect(
+      prompt.readPassphrase({passphraseEnv: true, passphraseStdin: true}),
+    ).rejects.toThrow('Use only one of --passphrase-stdin or --passphrase-env')
+  })
+})

--- a/packages/secret-vault/src/__tests__/vault.spec.ts
+++ b/packages/secret-vault/src/__tests__/vault.spec.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {decryptValues, DEFAULT_SCRYPT_PARAMS, encryptValues} from '../crypto'
+import {getVaultFilePath, readVaultValues, writeVaultValues} from '../vault'
+
+describe('vault', () => {
+  it('should resolve namespace vault file path', () => {
+    expect(getVaultFilePath('/tmp/repo', 'my-app')).toBe(
+      path.resolve('/tmp/repo', 'my-app', 'vault.json'),
+    )
+  })
+
+  it('should reject vault paths outside the repository', () => {
+    expect(() => getVaultFilePath('/tmp/repo', '..')).toThrow(
+      'Vault path must stay inside the repository',
+    )
+  })
+
+  it('should read and write plain vault values', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-plain-'))
+    const vaultPath = getVaultFilePath(tmpDir, 'app')
+
+    try {
+      await writeVaultValues(vaultPath, 'plain', {foo: 'bar'}, undefined)
+
+      await expect(readVaultValues(vaultPath, undefined)).resolves.toEqual({foo: 'bar'})
+      expect((await fs.promises.stat(vaultPath)).mode.toString(8).slice(-3)).toBe('600')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should round trip encrypted vault values', async () => {
+    const document = await encryptValues({foo: 'bar'}, 'passphrase')
+
+    expect(document.storage).toBe('encrypted')
+    expect(document.scryptParams).toEqual(DEFAULT_SCRYPT_PARAMS)
+    expect(document.ciphertext).not.toContain('bar')
+    await expect(decryptValues(document, 'passphrase')).resolves.toEqual({foo: 'bar'})
+  })
+
+  it('should decrypt legacy encrypted vault without scryptParams', async () => {
+    const document = await encryptValues({foo: 'bar'}, 'passphrase')
+    const legacyDocument = {
+      authTag: document.authTag,
+      ciphertext: document.ciphertext,
+      iv: document.iv,
+      kdf: document.kdf,
+      salt: document.salt,
+      storage: document.storage,
+      version: document.version,
+    }
+
+    await expect(readVaultValuesFromDocument(legacyDocument, 'passphrase')).resolves.toEqual({
+      foo: 'bar',
+    })
+  })
+
+  it('should reject wrong passphrase', async () => {
+    const document = await encryptValues({foo: 'bar'}, 'passphrase')
+
+    await expect(decryptValues(document, 'wrong')).rejects.toThrow('Failed to decrypt vault')
+  })
+
+  it('should require passphrase for encrypted write', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-encrypted-'))
+
+    try {
+      await expect(
+        writeVaultValues(getVaultFilePath(tmpDir, 'app'), 'encrypted', {foo: 'bar'}, undefined),
+      ).rejects.toThrow('Encrypted vault requires a passphrase')
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  it('should reject invalid vault json', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-invalid-json-'))
+    const vaultPath = getVaultFilePath(tmpDir, 'app')
+
+    await fs.promises.mkdir(path.dirname(vaultPath), {recursive: true})
+    await fs.promises.writeFile(vaultPath, '{not-json', 'utf8')
+
+    try {
+      await expect(readVaultValues(vaultPath, undefined)).rejects.toThrow(
+        `Vault file ${vaultPath} is not valid JSON`,
+      )
+    } finally {
+      await fs.promises.rm(tmpDir, {force: true, recursive: true})
+    }
+  })
+})
+
+const readVaultValuesFromDocument = async (
+  document: Record<string, unknown>,
+  passphrase: string,
+) => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-vault-legacy-'))
+  const vaultPath = getVaultFilePath(tmpDir, 'app')
+
+  try {
+    await fs.promises.mkdir(path.dirname(vaultPath), {recursive: true})
+    await fs.promises.writeFile(vaultPath, `${JSON.stringify(document, null, 2)}\n`, 'utf8')
+
+    return readVaultValues(vaultPath, passphrase)
+  } finally {
+    await fs.promises.rm(tmpDir, {force: true, recursive: true})
+  }
+}

--- a/packages/secret-vault/src/cli.ts
+++ b/packages/secret-vault/src/cli.ts
@@ -1,0 +1,232 @@
+/* eslint-disable no-console */
+import process from 'node:process'
+import {Command, Option} from 'commander'
+import {
+  addSecret,
+  createRepo,
+  exportSecrets,
+  importSecrets,
+  initVault,
+  listSecrets,
+  modifySecret,
+  syncSecrets,
+} from './commands'
+import {SecretVaultError} from './errors'
+import {createPrompt, readStdinText} from './prompt'
+import {runCommand} from './process'
+import type {StorageMode} from './types'
+
+interface GlobalOptions {
+  readonly config?: string
+  readonly namespace?: string
+  readonly passphraseEnv?: boolean
+  readonly passphraseStdin?: boolean
+}
+
+const storageOption = new Option('--storage <mode>', 'Storage mode')
+  .choices(['encrypted', 'plain'])
+  .default('encrypted')
+
+const createCommandOptions = (command: Command) => {
+  const options = command.optsWithGlobals<GlobalOptions>()
+
+  return {
+    configPath: options.config,
+    cwd: process.cwd(),
+    namespace: options.namespace,
+    prompt: createPrompt({
+      passphraseEnv: options.passphraseEnv === true,
+      passphraseStdin: options.passphraseStdin === true,
+    }),
+    readStdin: readStdinText,
+    runner: runCommand,
+  }
+}
+
+const handleError = (error: unknown) => {
+  if (error instanceof SecretVaultError) {
+    console.error(error.message)
+    process.exitCode = error.exitCode
+
+    return
+  }
+
+  throw error
+}
+
+const program = new Command()
+
+program
+  .name('secret-vault')
+  .description('Private git-backed secret vault')
+  .option('-c, --config <path>', 'Config path')
+  .option('-n, --namespace <name>', 'Vault namespace override')
+  .option('--passphrase-stdin', 'Read encrypted vault passphrase from stdin')
+  .option('--passphrase-env', 'Read encrypted vault passphrase from SECRET_VAULT_PASSPHRASE')
+
+program
+  .command('init')
+  .description('Create .secret-vault.json')
+  .option('--create-repo <name>', 'Create a private GitHub vault repository')
+  .option('--repository <url>', 'Vault repository URL')
+  .addOption(storageOption)
+  .action(
+    async (
+      options: {
+        createRepo?: string
+        repository?: string
+        storage: StorageMode
+      },
+      command,
+    ) => {
+      try {
+        await initVault({
+          ...createCommandOptions(command),
+          createRepoName: options.createRepo,
+          repository: options.repository,
+          storage: options.storage,
+        })
+      } catch (error) {
+        handleError(error)
+      }
+    },
+  )
+
+const repo = program.command('repo').description('Manage vault repository')
+
+repo
+  .command('create <name>')
+  .description('Create a private GitHub vault repository')
+  .action(async (name: string, command) => {
+    try {
+      const repository = await createRepo(name, createCommandOptions(command))
+
+      console.log(repository)
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program
+  .command('add <input>')
+  .description('Add a secret')
+  .option('--stdin', 'Read secret value from stdin')
+  .option('--value <value>', 'Secret value')
+  .action(async (input: string, options: {stdin?: boolean; value?: string}, command) => {
+    try {
+      const changed = await addSecret(input, {
+        ...createCommandOptions(command),
+        stdin: options.stdin,
+        value: options.value,
+      })
+
+      if (changed) {
+        console.log('Secret saved')
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program
+  .command('modify <input>')
+  .description('Modify a secret')
+  .option('--stdin', 'Read secret value from stdin')
+  .option('--value <value>', 'Secret value')
+  .action(async (input: string, options: {stdin?: boolean; value?: string}, command) => {
+    try {
+      const changed = await modifySecret(input, {
+        ...createCommandOptions(command),
+        stdin: options.stdin,
+        value: options.value,
+      })
+
+      if (changed) {
+        console.log('Secret saved')
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program
+  .command('import [source]')
+  .description('Import secrets from a dotenv file')
+  .option('--stdin', 'Read dotenv content from stdin')
+  .option('--confirm-overwrite', 'Prompt once before overwriting existing keys')
+  .action(
+    async (
+      source: string | undefined,
+      options: {confirmOverwrite?: boolean; stdin?: boolean},
+      command,
+    ) => {
+      try {
+        const keys = await importSecrets(source, {
+          ...createCommandOptions(command),
+          confirmOverwrite: options.confirmOverwrite,
+          stdin: options.stdin,
+        })
+
+        console.log(`Imported ${keys.length} secret${keys.length === 1 ? '' : 's'}`)
+      } catch (error) {
+        handleError(error)
+      }
+    },
+  )
+
+program
+  .command('list')
+  .description('List secret keys')
+  .action(async (_options, command) => {
+    try {
+      const keys = await listSecrets(createCommandOptions(command))
+
+      for (const key of keys) {
+        console.log(key)
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program
+  .command('sync')
+  .description('Export vault secrets to the configured env file')
+  .option('--out <path>', 'Override export path')
+  .action(async (options: {out?: string}, command) => {
+    try {
+      const result = await syncSecrets({
+        ...createCommandOptions(command),
+        out: options.out,
+      })
+
+      if (!result.skipped) {
+        console.log(
+          `Synced ${result.keyCount} secret${result.keyCount === 1 ? '' : 's'} to ${result.exportPath}`,
+        )
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program
+  .command('export')
+  .description('Print dotenv values')
+  .option('--out <path>', 'Write dotenv output to a file')
+  .action(async (options: {out?: string}, command) => {
+    try {
+      const content = await exportSecrets({
+        ...createCommandOptions(command),
+        out: options.out,
+      })
+
+      if (options.out === undefined && content !== '') {
+        console.log(content)
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+program.parseAsync(process.argv).catch(handleError)

--- a/packages/secret-vault/src/commands.ts
+++ b/packages/secret-vault/src/commands.ts
@@ -1,0 +1,379 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  DEFAULT_CONFIG_NAME,
+  loadConfig,
+  resolveConfigPath,
+  resolveExportPath,
+  writeConfig,
+} from './config'
+import {SecretVaultError} from './errors'
+import {commitAndPush, createGitHubRepository, syncRepository, warnIfPublicRepository} from './git'
+import {formatDotenv, parseAssignment, parseDotenv, parseKey} from './key-value'
+import {resolveNamespace} from './namespace'
+import {writeSecretFile} from './secret-file'
+import {getVaultFilePath, readVaultValues, writeVaultValues} from './vault'
+import type {CommandRunner, Prompt, SecretVaultConfig, StorageMode, VaultValues} from './types'
+
+interface CommandOptions {
+  readonly configPath?: string
+  readonly cwd: string
+  readonly namespace?: string
+  readonly prompt: Prompt
+  readonly readStdin?: () => Promise<string>
+  readonly repoPath?: string
+  readonly runner: CommandRunner
+}
+
+interface InitOptions extends CommandOptions {
+  readonly createRepoName?: string
+  readonly namespace?: string
+  readonly repository?: string
+  readonly storage?: StorageMode
+}
+
+interface ExportOptions extends CommandOptions {
+  readonly out?: string
+}
+
+interface SecretInputOptions extends CommandOptions {
+  readonly stdin?: boolean
+  readonly value?: string
+}
+
+interface ImportOptions extends CommandOptions {
+  readonly confirmOverwrite?: boolean
+  readonly stdin?: boolean
+}
+
+interface SyncOptions extends CommandOptions {
+  readonly out?: string
+}
+
+export interface SyncResult {
+  readonly exportPath: string
+  readonly keyCount: number
+  readonly skipped: false
+}
+
+export interface SyncSkippedResult {
+  readonly skipped: true
+}
+
+const loadCommandContext = async (options: CommandOptions) => {
+  const config = await loadConfig({
+    configPath: options.configPath,
+    cwd: options.cwd,
+  })
+  const namespace = await resolveNamespace({
+    cliNamespace: options.namespace,
+    configNamespace: config.namespace,
+    cwd: options.cwd,
+    runner: options.runner,
+  })
+
+  await warnIfPublicRepository(options.runner, config.repository)
+
+  const repoPath = await syncRepository(
+    {runner: options.runner},
+    config.repository,
+    options.repoPath,
+  )
+  const vaultPath = getVaultFilePath(repoPath, namespace)
+
+  return {
+    config,
+    namespace,
+    repoPath,
+    vaultPath,
+  }
+}
+
+const loadValues = async (
+  vaultPath: string,
+  storage: StorageMode,
+  prompt: Prompt,
+): Promise<readonly [VaultValues, string | undefined]> => {
+  if (storage === 'plain') {
+    return [await readVaultValues(vaultPath, undefined), undefined]
+  }
+
+  const passphrase = await prompt.passphrase()
+
+  return [await readVaultValues(vaultPath, passphrase), passphrase]
+}
+
+const readCommandStdin = async (options: CommandOptions) => {
+  if (options.readStdin === undefined) {
+    throw new SecretVaultError('stdin reader is not available')
+  }
+
+  return options.readStdin()
+}
+
+const resolveSecretInput = async (input: string, options: SecretInputOptions) => {
+  const hasValueOption = options.value !== undefined
+  const hasStdinOption = options.stdin === true
+
+  if (hasValueOption && hasStdinOption) {
+    throw new SecretVaultError('Use only one value source')
+  }
+
+  if (input.includes('=') && (hasValueOption || hasStdinOption)) {
+    throw new SecretVaultError('Use KEY=VALUE or KEY with --value/--stdin, not both')
+  }
+
+  if (hasValueOption) {
+    return {
+      key: parseKey(input),
+      value: options.value as string,
+    }
+  }
+
+  if (hasStdinOption) {
+    return {
+      key: parseKey(input),
+      value: await readCommandStdin(options),
+    }
+  }
+
+  if (input.includes('=')) {
+    return parseAssignment(input)
+  }
+
+  const key = parseKey(input)
+
+  return {
+    key,
+    value: await options.prompt.value(key),
+  }
+}
+
+const saveValues = async (
+  context: Awaited<ReturnType<typeof loadCommandContext>>,
+  values: VaultValues,
+  passphrase: string | undefined,
+  options: CommandOptions,
+) => {
+  await writeVaultValues(context.vaultPath, context.config.storage, values, passphrase)
+  await commitAndPush(
+    {prompt: options.prompt, runner: options.runner},
+    context.repoPath,
+    context.namespace,
+    context.vaultPath,
+  )
+}
+
+const writeDotenvExport = async (exportPath: string, values: VaultValues) => {
+  await writeSecretFile(exportPath, `${formatDotenv(values)}\n`)
+}
+
+export const initVault = async (options: InitOptions) => {
+  const configPath = resolveConfigPath({
+    configPath: options.configPath,
+    cwd: options.cwd,
+  })
+
+  if (fs.existsSync(configPath)) {
+    throw new SecretVaultError(`${path.basename(configPath)} already exists`)
+  }
+
+  const repository =
+    options.repository ??
+    (options.createRepoName === undefined
+      ? undefined
+      : await createGitHubRepository(options.runner, options.createRepoName))
+
+  if (repository === undefined) {
+    throw new SecretVaultError('Repository is required. Use --repository or --create-repo.')
+  }
+
+  // config 에 필요한 값은 리턴하고 config 는 이함수 호출된후 다른 곳에서 만들어 져야 함
+  const config: SecretVaultConfig =
+    options.namespace === undefined
+      ? {
+          repository,
+          storage: options.storage ?? 'encrypted',
+        }
+      : {
+          namespace: options.namespace,
+          repository,
+          storage: options.storage ?? 'encrypted',
+        }
+
+  // todo config 파일 생성 부분을 분리해야 함
+  await writeConfig(configPath, config)
+}
+
+export const createRepo = async (name: string, options: CommandOptions) => {
+  // 추후 옵션으로 gitlab 등 다른 저장소 생성 기능 추가 필요
+  const repository = await createGitHubRepository(options.runner, name)
+
+  // config 파일 생성 부분을 분리해야 함 이 함수의 역할은 지금은 구현되어 있지 않지만 gitlab 등 다른 저장소 생성시 구분하여 호출하는 통합 함수임
+
+  // todo config 파일 생성 부분을 분리해야 함
+  const configPath = resolveConfigPath({
+    configPath: options.configPath,
+    cwd: options.cwd,
+  })
+
+  // todo config 파일 생성 부분을 분리해야 함
+  const config: SecretVaultConfig = {
+    repository,
+    storage: 'encrypted',
+  }
+
+  // todo repo 만드는 부분과 config 파일 생성 부분을 분리해야 함
+  await writeConfig(configPath, config)
+
+  return repository
+}
+
+export const addSecret = async (input: string, options: SecretInputOptions) => {
+  const {key, value} = await resolveSecretInput(input, options)
+  const context = await loadCommandContext(options)
+  const [values, passphrase] = await loadValues(
+    context.vaultPath,
+    context.config.storage,
+    options.prompt,
+  )
+
+  if (values[key] !== undefined) {
+    const shouldOverwrite = await options.prompt.confirm(`${key} already exists. Overwrite?`)
+
+    if (!shouldOverwrite) {
+      return false
+    }
+  }
+
+  values[key] = value
+
+  await saveValues(context, values, passphrase, options)
+
+  return true
+}
+
+export const modifySecret = async (input: string, options: SecretInputOptions) => {
+  const {key, value} = await resolveSecretInput(input, options)
+  const context = await loadCommandContext(options)
+  const [values, passphrase] = await loadValues(
+    context.vaultPath,
+    context.config.storage,
+    options.prompt,
+  )
+
+  if (values[key] === undefined) {
+    const shouldCreate = await options.prompt.confirm(`${key} does not exist. Create it?`)
+
+    if (!shouldCreate) {
+      return false
+    }
+  }
+
+  values[key] = value
+
+  await saveValues(context, values, passphrase, options)
+
+  return true
+}
+
+export const importSecrets = async (source: string | undefined, options: ImportOptions) => {
+  if (source !== undefined && options.stdin === true) {
+    throw new SecretVaultError('Use a file path or --stdin, not both')
+  }
+
+  if (source === undefined && options.stdin !== true) {
+    throw new SecretVaultError('Import source is required. Pass a file path or --stdin.')
+  }
+
+  const content =
+    options.stdin === true
+      ? await readCommandStdin(options)
+      : await fs.promises.readFile(path.resolve(options.cwd, source as string), 'utf8')
+  const imported = parseDotenv(content)
+  const context = await loadCommandContext(options)
+  const [values, passphrase] = await loadValues(
+    context.vaultPath,
+    context.config.storage,
+    options.prompt,
+  )
+
+  const conflicts = Object.keys(imported)
+    .filter((key) => values[key] !== undefined)
+    .sort()
+
+  if (conflicts.length > 0) {
+    if (options.confirmOverwrite !== true) {
+      throw new SecretVaultError(
+        [
+          `Import would overwrite existing keys: ${conflicts.join(', ')}.`,
+          'Pass --confirm-overwrite to prompt before overwriting.',
+        ].join(' '),
+      )
+    }
+
+    const shouldOverwrite = await options.prompt.confirm(
+      `Overwrite ${conflicts.length} existing key${conflicts.length === 1 ? '' : 's'}: ${conflicts.join(', ')}?`,
+    )
+
+    if (!shouldOverwrite) {
+      return []
+    }
+  }
+
+  Object.assign(values, imported)
+
+  await saveValues(context, values, passphrase, options)
+
+  return Object.keys(imported).sort()
+}
+
+export const listSecrets = async (options: CommandOptions) => {
+  const context = await loadCommandContext(options)
+  const [values] = await loadValues(context.vaultPath, context.config.storage, options.prompt)
+
+  return Object.keys(values).sort()
+}
+
+export const exportSecrets = async (options: ExportOptions) => {
+  const context = await loadCommandContext(options)
+  const [values] = await loadValues(context.vaultPath, context.config.storage, options.prompt)
+  const content = formatDotenv(values)
+
+  if (options.out !== undefined) {
+    await writeDotenvExport(path.resolve(options.cwd, options.out), values)
+  }
+
+  return content
+}
+
+export const syncSecrets = async (
+  options: SyncOptions,
+): Promise<SyncResult | SyncSkippedResult> => {
+  const configPath = resolveConfigPath({
+    configPath: options.configPath,
+    cwd: options.cwd,
+  })
+
+  if (!fs.existsSync(configPath)) {
+    return {skipped: true}
+  }
+
+  const context = await loadCommandContext(options)
+  const [values] = await loadValues(context.vaultPath, context.config.storage, options.prompt)
+  const exportPath = resolveExportPath({
+    cwd: options.cwd,
+    exportPath: context.config.exportPath,
+    out: options.out,
+  })
+
+  await writeSecretFile(exportPath, `${formatDotenv(values)}\n`)
+
+  return {
+    exportPath,
+    keyCount: Object.keys(values).length,
+    skipped: false,
+  }
+}
+
+export const getDefaultConfigName = () => DEFAULT_CONFIG_NAME

--- a/packages/secret-vault/src/config.ts
+++ b/packages/secret-vault/src/config.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {SecretVaultError} from './errors'
+import {parseJsonText} from './json'
+import type {ResolvedConfig, SecretVaultConfig, StorageMode} from './types'
+
+export const DEFAULT_CONFIG_NAME = '.secret-vault.json'
+export const DEFAULT_EXPORT_PATH = '.env.local'
+
+export interface LoadConfigOptions {
+  readonly configPath?: string
+  readonly cwd: string
+}
+
+const storageModes = new Set<StorageMode>(['encrypted', 'plain'])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export const resolveConfigPath = (options: LoadConfigOptions) => {
+  const configPath = options.configPath ?? DEFAULT_CONFIG_NAME
+
+  return path.isAbsolute(configPath) ? configPath : path.join(options.cwd, configPath)
+}
+
+export const parseConfig = (value: unknown): SecretVaultConfig => {
+  if (!isRecord(value)) {
+    throw new SecretVaultError('Config must be a JSON object')
+  }
+
+  if ('vaultPath' in value) {
+    throw new SecretVaultError(
+      'vaultPath is not supported; vaults are stored at <namespace>/vault.json',
+    )
+  }
+
+  if (typeof value.repository !== 'string' || value.repository.trim() === '') {
+    throw new SecretVaultError('Config repository must be a non-empty string')
+  }
+
+  if (value.namespace !== undefined && typeof value.namespace !== 'string') {
+    throw new SecretVaultError('Config namespace must be a string')
+  }
+
+  if (value.storage !== undefined) {
+    if (typeof value.storage !== 'string' || !storageModes.has(value.storage as StorageMode)) {
+      throw new SecretVaultError('Config storage must be "encrypted" or "plain"')
+    }
+  }
+
+  if (value.exportPath !== undefined && typeof value.exportPath !== 'string') {
+    throw new SecretVaultError('Config exportPath must be a string')
+  }
+
+  return {
+    exportPath: value.exportPath,
+    namespace: value.namespace,
+    repository: value.repository,
+    storage: value.storage as StorageMode | undefined,
+  }
+}
+
+export const resolveExportPath = (options: {
+  readonly cwd: string
+  readonly exportPath: string
+  readonly out?: string
+}) => path.resolve(options.cwd, options.out ?? options.exportPath)
+
+export const loadConfig = async (options: LoadConfigOptions): Promise<ResolvedConfig> => {
+  const configPath = resolveConfigPath(options)
+
+  let content: string
+
+  try {
+    content = await fs.promises.readFile(configPath, 'utf8')
+  } catch (error) {
+    if (error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new SecretVaultError(`Config file not found: ${configPath}`)
+    }
+
+    throw error
+  }
+
+  const parsed = parseConfig(parseJsonText(content, `Config file ${configPath}`))
+
+  return {
+    ...parsed,
+    configPath,
+    exportPath: parsed.exportPath ?? DEFAULT_EXPORT_PATH,
+    storage: parsed.storage ?? 'encrypted',
+  }
+}
+
+export const writeConfig = async (configPath: string, config: SecretVaultConfig) => {
+  const content = `${JSON.stringify(config, null, 2)}\n`
+
+  await fs.promises.writeFile(configPath, content, 'utf8')
+}

--- a/packages/secret-vault/src/crypto.ts
+++ b/packages/secret-vault/src/crypto.ts
@@ -1,0 +1,136 @@
+import crypto from 'node:crypto'
+import {SecretVaultError} from './errors'
+import type {VaultValues} from './types'
+
+const KEY_LENGTH = 32
+const SALT_LENGTH = 16
+const IV_LENGTH = 12
+
+export interface ScryptParams {
+  readonly N: number
+  readonly p: number
+  readonly r: number
+}
+
+// AI_NOTE - Node scrypt defaults; stored in new vaults so KDF cost can be raised without breaking old files.
+export const DEFAULT_SCRYPT_PARAMS: ScryptParams = {
+  N: 16384,
+  p: 1,
+  r: 8,
+}
+
+export interface EncryptedVaultDocument {
+  readonly authTag: string
+  readonly ciphertext: string
+  readonly iv: string
+  readonly kdf: 'scrypt'
+  readonly salt: string
+  readonly scryptParams: ScryptParams
+  readonly storage: 'encrypted'
+  readonly version: 1
+}
+
+const deriveKey = (passphrase: string, salt: Buffer, scryptParams: ScryptParams) =>
+  new Promise<Buffer>((resolve, reject) => {
+    crypto.scrypt(passphrase, salt, KEY_LENGTH, scryptParams, (error, derivedKey) => {
+      if (error) {
+        reject(error)
+
+        return
+      }
+
+      resolve(derivedKey)
+    })
+  })
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const parsePositiveInteger = (value: unknown, field: string) => {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new SecretVaultError(`Encrypted vault scryptParams.${field} must be a positive integer`)
+  }
+
+  return value
+}
+
+export const parseScryptParams = (value: unknown): ScryptParams => {
+  if (value === undefined) {
+    return DEFAULT_SCRYPT_PARAMS
+  }
+
+  if (!isRecord(value)) {
+    throw new SecretVaultError('Encrypted vault scryptParams must be an object')
+  }
+
+  return {
+    N: parsePositiveInteger(value.N, 'N'),
+    p: parsePositiveInteger(value.p, 'p'),
+    r: parsePositiveInteger(value.r, 'r'),
+  }
+}
+
+export const encryptValues = async (
+  values: VaultValues,
+  passphrase: string,
+): Promise<EncryptedVaultDocument> => {
+  const salt = crypto.randomBytes(SALT_LENGTH)
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const scryptParams = DEFAULT_SCRYPT_PARAMS
+  const key = await deriveKey(passphrase, salt, scryptParams)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(values), 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return {
+    authTag: authTag.toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+    iv: iv.toString('base64'),
+    kdf: 'scrypt',
+    salt: salt.toString('base64'),
+    scryptParams,
+    storage: 'encrypted',
+    version: 1,
+  }
+}
+
+export const decryptValues = async (
+  document: EncryptedVaultDocument,
+  passphrase: string,
+): Promise<VaultValues> => {
+  try {
+    const salt = Buffer.from(document.salt, 'base64')
+    const iv = Buffer.from(document.iv, 'base64')
+    const authTag = Buffer.from(document.authTag, 'base64')
+    const ciphertext = Buffer.from(document.ciphertext, 'base64')
+    const key = await deriveKey(passphrase, salt, document.scryptParams)
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+
+    decipher.setAuthTag(authTag)
+
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
+      'utf8',
+    )
+    const parsed = JSON.parse(plaintext) as unknown
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new SecretVaultError('Decrypted vault payload must be an object')
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => {
+        if (typeof value !== 'string') {
+          throw new SecretVaultError(`Decrypted vault value for ${key} must be a string`)
+        }
+
+        return [key, value]
+      }),
+    )
+  } catch (error) {
+    if (error instanceof SecretVaultError) {
+      throw error
+    }
+
+    throw new SecretVaultError('Failed to decrypt vault; check the passphrase')
+  }
+}

--- a/packages/secret-vault/src/errors.ts
+++ b/packages/secret-vault/src/errors.ts
@@ -1,0 +1,9 @@
+export class SecretVaultError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number = 1,
+  ) {
+    super(message)
+    this.name = 'SecretVaultError'
+  }
+}

--- a/packages/secret-vault/src/git.ts
+++ b/packages/secret-vault/src/git.ts
@@ -1,0 +1,246 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type {Options as ExecaOptions} from 'execa'
+import {SecretVaultError} from './errors'
+import type {CommandRunner, Prompt} from './types'
+
+export interface GitContext {
+  readonly runner: CommandRunner
+}
+
+export interface CommitAndPushContext extends GitContext {
+  readonly prompt: Prompt
+}
+
+type CommandAttempt =
+  | {
+      readonly stderr: string
+      readonly stdout: string
+      readonly success: true
+    }
+  | {
+      readonly message: string
+      readonly stderr: string
+      readonly stdout: string
+      readonly success: false
+    }
+
+const formatCommandOutput = (stdout: string, stderr: string, message: string) => {
+  const lines = [stdout.trim(), stderr.trim(), message.trim()].filter((line) => line !== '')
+
+  return lines.join('\n')
+}
+
+const isMergeInProgress = (repoPath: string) =>
+  fs.existsSync(path.join(repoPath, '.git', 'MERGE_HEAD'))
+
+const buildManualResolutionMessage = (repoPath: string, vaultRelativePath: string) =>
+  [
+    'Vault push cancelled due to a merge conflict.',
+    `Local cache: ${repoPath}`,
+    'Your vault changes are committed locally but not pushed.',
+    '',
+    'Resolve manually:',
+    `1. cd ${repoPath}`,
+    '2. git status',
+    `3. Resolve conflicts in ${vaultRelativePath}`,
+    `4. git add ${vaultRelativePath}`,
+    '5. git commit',
+    '6. git push',
+  ].join('\n')
+
+const tryRunner = async (
+  runner: CommandRunner,
+  file: string,
+  args: readonly string[],
+  options?: ExecaOptions,
+): Promise<CommandAttempt> => {
+  try {
+    const result = await runner(file, args, options)
+
+    return {
+      stderr: result.stderr,
+      stdout: result.stdout,
+      success: true,
+    }
+  } catch (error) {
+    if (error instanceof SecretVaultError) {
+      return {
+        message: error.message,
+        stderr: '',
+        stdout: '',
+        success: false,
+      }
+    }
+
+    if (error !== null && typeof error === 'object') {
+      const commandError = error as {message?: string; stderr?: unknown; stdout?: unknown}
+
+      return {
+        message: commandError.message ?? 'Command failed',
+        stderr: String(commandError.stderr ?? ''),
+        stdout: String(commandError.stdout ?? ''),
+        success: false,
+      }
+    }
+
+    throw error
+  }
+}
+
+interface PullBeforePushOptions {
+  readonly context: CommitAndPushContext
+  readonly localVaultContent: string
+  readonly namespace: string
+  readonly repoPath: string
+  readonly vaultPath: string
+}
+
+const pullBeforePush = async (options: PullBeforePushOptions) => {
+  const {context, localVaultContent, namespace, repoPath, vaultPath} = options
+  const vaultRelativePath = `${namespace}/vault.json`
+  const pullResult = await tryRunner(context.runner, 'git', ['pull', '--no-rebase'], {
+    cwd: repoPath,
+  })
+
+  if (pullResult.success) {
+    return
+  }
+
+  const details = formatCommandOutput(pullResult.stdout, pullResult.stderr, pullResult.message)
+
+  if (!isMergeInProgress(repoPath)) {
+    throw new SecretVaultError(`Failed to sync vault repository before push:\n${details}`)
+  }
+
+  const shouldOverwrite = await context.prompt.confirm(
+    `Vault sync conflict:\n${details}\n\nOverwrite remote changes with your local vault?`,
+  )
+
+  if (!shouldOverwrite) {
+    await tryRunner(context.runner, 'git', ['merge', '--abort'], {cwd: repoPath})
+    throw new SecretVaultError(buildManualResolutionMessage(repoPath, vaultRelativePath))
+  }
+
+  await context.runner('git', ['checkout', '--ours', '--', vaultRelativePath], {cwd: repoPath})
+  await fs.promises.writeFile(vaultPath, localVaultContent, 'utf8')
+  await context.runner('git', ['add', vaultRelativePath], {cwd: repoPath})
+  await context.runner('git', ['commit', '--no-edit'], {cwd: repoPath})
+}
+
+export const getRepoCachePath = (repository: string) => {
+  const repoKey = repository
+    .replace(/\.git$/u, '')
+    .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    .replace(/^-|-$/gu, '')
+
+  return path.join(os.homedir(), '.cache', 'secret-vault', repoKey)
+}
+
+export const syncRepository = async (
+  context: GitContext,
+  repository: string,
+  repoPath: string = getRepoCachePath(repository),
+) => {
+  if (fs.existsSync(path.join(repoPath, '.git'))) {
+    await context.runner('git', ['pull', '--ff-only'], {cwd: repoPath})
+
+    return repoPath
+  }
+
+  await fs.promises.mkdir(path.dirname(repoPath), {recursive: true})
+  await context.runner('git', ['clone', repository, repoPath])
+
+  return repoPath
+}
+
+export const commitAndPush = async (
+  context: CommitAndPushContext,
+  repoPath: string,
+  namespace: string,
+  vaultPath: string,
+) => {
+  const vaultRelativePath = `${namespace}/vault.json`
+  const localVaultContent = await fs.promises.readFile(vaultPath, 'utf8')
+
+  await context.runner('git', ['add', vaultRelativePath], {cwd: repoPath})
+
+  const diff = await context.runner('git', ['diff', '--cached', '--name-only'], {cwd: repoPath})
+
+  if (diff.stdout.trim() === '') {
+    return false
+  }
+
+  await context.runner('git', ['commit', '-m', `Update secret vault namespace ${namespace}`], {
+    cwd: repoPath,
+  })
+
+  await pullBeforePush({
+    context,
+    localVaultContent,
+    namespace,
+    repoPath,
+    vaultPath,
+  })
+
+  const pushResult = await tryRunner(context.runner, 'git', ['push'], {cwd: repoPath})
+
+  if (!pushResult.success) {
+    throw new SecretVaultError(
+      `Failed to push vault repository:\n${formatCommandOutput(
+        pushResult.stdout,
+        pushResult.stderr,
+        pushResult.message,
+      )}`,
+    )
+  }
+
+  return true
+}
+
+export const ensureGhInstalled = async (runner: CommandRunner) => {
+  try {
+    await runner('gh', ['--version'])
+  } catch {
+    throw new SecretVaultError('GitHub CLI is required. Install it from https://cli.github.com/')
+  }
+}
+
+export const ensureGhAuth = async (runner: CommandRunner) => {
+  try {
+    await runner('gh', ['auth', 'status'])
+  } catch {
+    await runner('gh', ['auth', 'login'], {stdio: 'inherit'})
+  }
+}
+
+export const createGitHubRepository = async (runner: CommandRunner, name: string) => {
+  await ensureGhInstalled(runner)
+  await ensureGhAuth(runner)
+  await runner('gh', ['repo', 'create', name, '--private'])
+
+  const view = await runner('gh', ['repo', 'view', name, '--json', 'sshUrl', '-q', '.sshUrl'])
+
+  return view.stdout.trim()
+}
+
+export const warnIfPublicRepository = async (runner: CommandRunner, repository: string) => {
+  try {
+    const view = await runner('gh', [
+      'repo',
+      'view',
+      repository,
+      '--json',
+      'visibility',
+      '-q',
+      '.visibility',
+    ])
+
+    if (view.stdout.trim().toUpperCase() === 'PUBLIC') {
+      process.stderr.write('Warning: configured vault repository is public.\n')
+    }
+  } catch {
+    process.stderr.write('Warning: unable to verify vault repository visibility.\n')
+  }
+}

--- a/packages/secret-vault/src/index.ts
+++ b/packages/secret-vault/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  DEFAULT_CONFIG_NAME,
+  DEFAULT_EXPORT_PATH,
+  loadConfig,
+  parseConfig,
+  resolveConfigPath,
+  resolveExportPath,
+} from './config'
+export {DEFAULT_SCRYPT_PARAMS, decryptValues, encryptValues, parseScryptParams} from './crypto'
+export type {ScryptParams} from './crypto'
+export {SecretVaultError} from './errors'
+export {parseAssignment, formatDotenv} from './key-value'
+export {normalizeNamespace, resolveNamespace} from './namespace'
+export {getVaultFilePath, readVaultValues, writeVaultValues} from './vault'
+export type {SecretVaultConfig, StorageMode, VaultValues} from './types'

--- a/packages/secret-vault/src/json.ts
+++ b/packages/secret-vault/src/json.ts
@@ -1,0 +1,9 @@
+import {SecretVaultError} from './errors'
+
+export const parseJsonText = (content: string, source: string): unknown => {
+  try {
+    return JSON.parse(content)
+  } catch {
+    throw new SecretVaultError(`${source} is not valid JSON`)
+  }
+}

--- a/packages/secret-vault/src/key-value.ts
+++ b/packages/secret-vault/src/key-value.ts
@@ -1,0 +1,70 @@
+import {SecretVaultError} from './errors'
+
+const stripMatchingQuotes = (value: string) => {
+  const trimmed = value.trim()
+
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed
+}
+
+export interface ParsedAssignment {
+  readonly key: string
+  readonly value: string
+}
+
+export const parseKey = (input: string) => {
+  const key = stripMatchingQuotes(input)
+
+  if (key === '') {
+    throw new SecretVaultError('Secret key must not be empty')
+  }
+
+  if (key.includes('=')) {
+    throw new SecretVaultError('Secret key must not contain "="')
+  }
+
+  return key
+}
+
+export const parseAssignment = (input: string): ParsedAssignment => {
+  const separatorIndex = input.indexOf('=')
+
+  if (separatorIndex < 0) {
+    throw new SecretVaultError('Expected KEY=VALUE')
+  }
+
+  const key = stripMatchingQuotes(input.slice(0, separatorIndex))
+  const value = stripMatchingQuotes(input.slice(separatorIndex + 1))
+
+  parseKey(key)
+
+  return {key, value}
+}
+
+export const parseDotenv = (content: string) => {
+  const values: Record<string, string> = {}
+
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const line = rawLine.trim()
+
+    if (line !== '' && !line.startsWith('#')) {
+      const {key, value} = parseAssignment(line)
+
+      values[key] = value
+    }
+  }
+
+  return values
+}
+
+export const formatDotenv = (values: Record<string, string>) =>
+  Object.entries(values)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join('\n')

--- a/packages/secret-vault/src/namespace.ts
+++ b/packages/secret-vault/src/namespace.ts
@@ -1,0 +1,47 @@
+import path from 'node:path'
+import {SecretVaultError} from './errors'
+import type {CommandRunner} from './types'
+
+const RESERVED_NAMES = new Set(['.', '..'])
+
+export interface ResolveNamespaceOptions {
+  readonly cliNamespace?: string
+  readonly configNamespace?: string
+  readonly cwd: string
+  readonly runner: CommandRunner
+}
+
+export const normalizeNamespace = (namespace: string) => {
+  const normalized = namespace
+    .trim()
+    .replace(/\.git$/u, '')
+    .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    .replace(/-{2,}/gu, '-')
+    .replace(/^-|-$/gu, '')
+
+  if (
+    normalized === '' ||
+    RESERVED_NAMES.has(normalized) ||
+    path.basename(normalized) !== normalized
+  ) {
+    throw new SecretVaultError('Namespace must be a single filesystem-safe path segment')
+  }
+
+  return normalized
+}
+
+export const resolveNamespace = async (options: ResolveNamespaceOptions) => {
+  if (options.cliNamespace !== undefined && options.cliNamespace.trim() !== '') {
+    return normalizeNamespace(options.cliNamespace)
+  }
+
+  if (options.configNamespace !== undefined && options.configNamespace.trim() !== '') {
+    return normalizeNamespace(options.configNamespace)
+  }
+
+  const result = await options.runner('git', ['remote', 'get-url', 'origin'], {
+    cwd: options.cwd,
+  })
+
+  return normalizeNamespace(result.stdout)
+}

--- a/packages/secret-vault/src/process.ts
+++ b/packages/secret-vault/src/process.ts
@@ -1,0 +1,45 @@
+import {execa, type Options as ExecaOptions} from 'execa'
+import {SecretVaultError} from './errors'
+import type {CommandRunner} from './types'
+
+const formatCommandLabel = (file: string, args: readonly string[]) => `${file} ${args.join(' ')}`
+
+const formatCommandFailure = (error: unknown, commandLabel: string) => {
+  if (error instanceof SecretVaultError) {
+    return error.message
+  }
+
+  if (error !== null && typeof error === 'object') {
+    const commandError = error as {message?: string; stderr?: unknown; stdout?: unknown}
+    const lines = [
+      String(commandError.stdout ?? '').trim(),
+      String(commandError.stderr ?? '').trim(),
+      String(commandError.message ?? 'Command failed').trim(),
+    ].filter((line) => line !== '')
+
+    if (lines.length > 0) {
+      return `Command failed (${commandLabel}):\n${lines.join('\n')}`
+    }
+  }
+
+  return `Command failed (${commandLabel})`
+}
+
+export const runCommand: CommandRunner = async (
+  file: string,
+  args: readonly string[],
+  options?: ExecaOptions,
+) => {
+  const commandLabel = formatCommandLabel(file, args)
+
+  try {
+    const result = await execa(file, [...args], options)
+
+    return {
+      stderr: String(result.stderr ?? ''),
+      stdout: String(result.stdout ?? ''),
+    }
+  } catch (error) {
+    throw new SecretVaultError(formatCommandFailure(error, commandLabel))
+  }
+}

--- a/packages/secret-vault/src/prompt.ts
+++ b/packages/secret-vault/src/prompt.ts
@@ -1,0 +1,141 @@
+import readline from 'node:readline'
+import {stdin as defaultStdin, stdout as defaultStdout} from 'node:process'
+import type {Readable, Writable} from 'node:stream'
+import {SecretVaultError} from './errors'
+import type {Prompt} from './types'
+
+const SIGINT_EXIT_CODE = 130
+
+interface TtyReadable extends Readable {
+  readonly isTTY?: boolean
+  setRawMode?: (mode: boolean) => void
+}
+
+export const confirm = async (message: string) => {
+  const answer = await new Promise<string>((resolve) => {
+    const interfaceValue = readline.createInterface({
+      input: defaultStdin,
+      output: defaultStdout,
+    })
+
+    interfaceValue.question(`${message} (y/N) `, (value) => {
+      interfaceValue.close()
+      resolve(value.trim().toLowerCase())
+    })
+  })
+
+  return answer === 'y' || answer === 'yes'
+}
+
+export const readStdinText = async (input: Readable = defaultStdin) => {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of input) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)))
+  }
+
+  return Buffer.concat(chunks).toString('utf8').trimEnd()
+}
+
+export const promptHidden = async (
+  message: string,
+  input: TtyReadable = defaultStdin,
+  output: Writable = defaultStdout,
+) => {
+  output.write(message)
+
+  if (!input.isTTY || input.setRawMode === undefined) {
+    const interfaceValue = readline.createInterface({input, output})
+
+    return new Promise<string>((resolve) => {
+      interfaceValue.question('', (value) => {
+        interfaceValue.close()
+        resolve(value)
+      })
+    })
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    let value = ''
+
+    const cleanup = () => {
+      input.setRawMode?.(false)
+      input.off('keypress', onKeypress)
+      output.write('\n')
+    }
+
+    const onKeypress = (chunk: string, key: readline.Key) => {
+      if (key.ctrl === true && key.name === 'c') {
+        cleanup()
+        reject(new SecretVaultError('Passphrase prompt cancelled', SIGINT_EXIT_CODE))
+
+        return
+      }
+
+      if (key.name === 'return' || key.name === 'enter') {
+        cleanup()
+        resolve(value)
+
+        return
+      }
+
+      if (key.name === 'backspace') {
+        value = value.slice(0, -1)
+
+        return
+      }
+
+      if (chunk !== undefined && chunk >= ' ') {
+        value += chunk
+      }
+    }
+
+    readline.emitKeypressEvents(input)
+    input.setRawMode?.(true)
+    input.on('keypress', onKeypress)
+    input.resume()
+  })
+}
+
+export interface CreatePromptOptions {
+  readonly passphraseEnv?: boolean
+  readonly passphraseStdin?: boolean
+  readonly readStdin?: () => Promise<string>
+}
+
+export const readPassphrase = async (options: CreatePromptOptions = {}) => {
+  const passphraseStdin = options.passphraseStdin === true
+  const passphraseEnv = options.passphraseEnv === true
+
+  if (passphraseStdin && passphraseEnv) {
+    throw new SecretVaultError('Use only one of --passphrase-stdin or --passphrase-env')
+  }
+
+  if (passphraseEnv) {
+    const envValue = process.env.SECRET_VAULT_PASSPHRASE
+
+    if (envValue === undefined || envValue === '') {
+      throw new SecretVaultError('SECRET_VAULT_PASSPHRASE is not set')
+    }
+
+    process.stderr.write(
+      'Warning: using SECRET_VAULT_PASSPHRASE from environment; prefer --passphrase-stdin in CI.\n',
+    )
+
+    return envValue
+  }
+
+  if (passphraseStdin) {
+    return (options.readStdin ?? readStdinText)()
+  }
+
+  return promptHidden('Passphrase: ')
+}
+
+export const createPrompt = (options: CreatePromptOptions = {}): Prompt => {
+  return {
+    confirm,
+    passphrase: () => readPassphrase(options),
+    value: (key) => promptHidden(`Value for ${key}: `),
+  }
+}

--- a/packages/secret-vault/src/secret-file.ts
+++ b/packages/secret-vault/src/secret-file.ts
@@ -1,0 +1,9 @@
+import fs from 'node:fs'
+
+export const SECRET_FILE_MODE = 0o600
+
+/** Writes a secret file with owner-only permissions. */
+export const writeSecretFile = async (filePath: string, content: string) => {
+  await fs.promises.writeFile(filePath, content, {encoding: 'utf8', mode: SECRET_FILE_MODE})
+  await fs.promises.chmod(filePath, SECRET_FILE_MODE)
+}

--- a/packages/secret-vault/src/types.ts
+++ b/packages/secret-vault/src/types.ts
@@ -1,0 +1,35 @@
+import type {Options as ExecaOptions} from 'execa'
+
+export type StorageMode = 'encrypted' | 'plain'
+
+export interface SecretVaultConfig {
+  readonly exportPath?: string
+  readonly namespace?: string
+  readonly repository: string
+  readonly storage?: StorageMode
+}
+
+export interface ResolvedConfig extends SecretVaultConfig {
+  readonly configPath: string
+  readonly exportPath: string
+  readonly storage: StorageMode
+}
+
+export interface CommandResult {
+  readonly stderr: string
+  readonly stdout: string
+}
+
+export type CommandRunner = (
+  file: string,
+  args: readonly string[],
+  options?: ExecaOptions,
+) => Promise<CommandResult>
+
+export interface Prompt {
+  readonly confirm: (message: string) => Promise<boolean>
+  readonly passphrase: () => Promise<string>
+  readonly value: (key: string) => Promise<string>
+}
+
+export type VaultValues = Record<string, string>

--- a/packages/secret-vault/src/vault.ts
+++ b/packages/secret-vault/src/vault.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  decryptValues,
+  type EncryptedVaultDocument,
+  encryptValues,
+  parseScryptParams,
+} from './crypto'
+import {SecretVaultError} from './errors'
+import {parseJsonText} from './json'
+import {writeSecretFile} from './secret-file'
+import type {StorageMode, VaultValues} from './types'
+
+export interface PlainVaultDocument {
+  readonly storage: 'plain'
+  readonly values: VaultValues
+  readonly version: 1
+}
+
+export type VaultDocument = EncryptedVaultDocument | PlainVaultDocument
+
+export const getVaultFilePath = (repoPath: string, namespace: string) => {
+  const vaultPath = path.resolve(repoPath, namespace, 'vault.json')
+  const repoRoot = `${path.resolve(repoPath)}${path.sep}`
+
+  if (!vaultPath.startsWith(repoRoot)) {
+    throw new SecretVaultError('Vault path must stay inside the repository')
+  }
+
+  return vaultPath
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const parsePlainValues = (value: unknown): VaultValues => {
+  if (!isRecord(value)) {
+    throw new SecretVaultError('Plain vault values must be an object')
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (typeof entry !== 'string') {
+        throw new SecretVaultError(`Plain vault value for ${key} must be a string`)
+      }
+
+      return [key, entry]
+    }),
+  )
+}
+
+const parseDocument = (value: unknown): VaultDocument => {
+  if (!isRecord(value) || value.version !== 1) {
+    throw new SecretVaultError('Vault document must be a version 1 object')
+  }
+
+  if (value.storage === 'plain') {
+    return {
+      storage: 'plain',
+      values: parsePlainValues(value.values),
+      version: 1,
+    }
+  }
+
+  if (value.storage === 'encrypted') {
+    if (typeof value.authTag !== 'string') {
+      throw new SecretVaultError('Encrypted vault authTag must be a string')
+    }
+
+    if (typeof value.ciphertext !== 'string') {
+      throw new SecretVaultError('Encrypted vault ciphertext must be a string')
+    }
+
+    if (typeof value.iv !== 'string') {
+      throw new SecretVaultError('Encrypted vault iv must be a string')
+    }
+
+    if (typeof value.salt !== 'string') {
+      throw new SecretVaultError('Encrypted vault salt must be a string')
+    }
+
+    if (value.kdf !== 'scrypt') {
+      throw new SecretVaultError('Encrypted vault kdf must be scrypt')
+    }
+
+    return {
+      authTag: value.authTag,
+      ciphertext: value.ciphertext,
+      iv: value.iv,
+      kdf: 'scrypt',
+      salt: value.salt,
+      scryptParams: parseScryptParams(value.scryptParams),
+      storage: 'encrypted',
+      version: 1,
+    }
+  }
+
+  throw new SecretVaultError('Vault storage must be "encrypted" or "plain"')
+}
+
+export const readVaultValues = async (
+  filePath: string,
+  passphrase: string | undefined,
+): Promise<VaultValues> => {
+  if (!fs.existsSync(filePath)) {
+    return {}
+  }
+
+  const content = await fs.promises.readFile(filePath, 'utf8')
+  const document = parseDocument(parseJsonText(content, `Vault file ${filePath}`))
+
+  if (document.storage === 'plain') {
+    return document.values
+  }
+
+  if (passphrase === undefined) {
+    throw new SecretVaultError('Encrypted vault requires a passphrase')
+  }
+
+  return decryptValues(document, passphrase)
+}
+
+export const writeVaultValues = async (
+  filePath: string,
+  storage: StorageMode,
+  values: VaultValues,
+  passphrase: string | undefined,
+) => {
+  await fs.promises.mkdir(path.dirname(filePath), {recursive: true})
+
+  if (storage === 'plain') {
+    const document: PlainVaultDocument = {
+      storage: 'plain',
+      values,
+      version: 1,
+    }
+
+    await writeSecretFile(filePath, `${JSON.stringify(document, null, 2)}\n`)
+
+    return
+  }
+
+  if (passphrase === undefined) {
+    throw new SecretVaultError('Encrypted vault requires a passphrase')
+  }
+
+  const document = await encryptValues(values, passphrase)
+
+  await writeSecretFile(filePath, `${JSON.stringify(document, null, 2)}\n`)
+}

--- a/packages/secret-vault/tsconfig.json
+++ b/packages/secret-vault/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  },
+  "extends": ["../../tsconfig.json"],
+  "include": ["src/**/*.ts", "vite.config.mts"]
+}

--- a/packages/secret-vault/vite.config.mts
+++ b/packages/secret-vault/vite.config.mts
@@ -1,0 +1,17 @@
+import {createConfig} from '@winter-love/vite-lib-config'
+
+export default createConfig({
+  entry: {
+    cli: 'src/cli.ts',
+  },
+  external: [
+    'node:crypto',
+    'node:fs',
+    'node:os',
+    'node:path',
+    'node:process',
+    'node:readline',
+    'node:stream',
+    'node:util',
+  ],
+})

--- a/packages/vite-lib-config/package.json
+++ b/packages/vite-lib-config/package.json
@@ -11,6 +11,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs"
     },
     "./require": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,34 @@ importers:
         specifier: 'catalog:'
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
 
+  packages/secret-vault:
+    dependencies:
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
+      execa:
+        specifier: 'catalog:'
+        version: 9.6.1
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.17
+      '@winter-love/vite-lib-config':
+        specifier: workspace:*
+        version: link:../vite-lib-config
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite-plugin-dts:
+        specifier: 'catalog:'
+        version: 4.5.4(@types/node@22.19.17)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.0.8(vitest@4.1.5))(happy-dom@20.9.0)(jsdom@26.1.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+
   packages/solid-components:
     dependencies:
       '@winter-love/solid-use':
@@ -11834,6 +11862,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@22.19.17)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor-model@7.33.8(@types/node@25.6.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
@@ -11851,6 +11887,24 @@ snapshots:
       '@rushstack/rig-package': 0.7.3
       '@rushstack/terminal': 0.24.0(@types/node@20.11.18)
       '@rushstack/ts-command-line': 5.3.9(@types/node@20.11.18)
+      diff: 8.0.3
+      minimatch: 10.2.3
+      resolve: 1.22.12
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.58.7(@types/node@22.19.17)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@22.19.17)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@22.19.17)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@22.19.17)
       diff: 8.0.3
       minimatch: 10.2.3
       resolve: 1.22.12
@@ -12757,6 +12811,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.11.18
 
+  '@rushstack/node-core-library@5.23.1(@types/node@22.19.17)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.4
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.12
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 22.19.17
+
   '@rushstack/node-core-library@5.23.1(@types/node@25.6.0)':
     dependencies:
       ajv: 8.18.0
@@ -12773,6 +12840,10 @@ snapshots:
   '@rushstack/problem-matcher@0.2.1(@types/node@20.11.18)':
     optionalDependencies:
       '@types/node': 20.11.18
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@rushstack/problem-matcher@0.2.1(@types/node@25.6.0)':
     optionalDependencies:
@@ -12791,6 +12862,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.11.18
 
+  '@rushstack/terminal@0.24.0(@types/node@22.19.17)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.17)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@22.19.17)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 22.19.17
+
   '@rushstack/terminal@0.24.0(@types/node@25.6.0)':
     dependencies:
       '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
@@ -12802,6 +12881,15 @@ snapshots:
   '@rushstack/ts-command-line@5.3.9(@types/node@20.11.18)':
     dependencies:
       '@rushstack/terminal': 0.24.0(@types/node@20.11.18)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/ts-command-line@5.3.9(@types/node@22.19.17)':
+    dependencies:
+      '@rushstack/terminal': 0.24.0(@types/node@22.19.17)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -13906,6 +13994,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@20.11.18)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -19714,6 +19810,25 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-plugin-dts@4.5.4(@types/node@22.19.17)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@22.19.17)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
   vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
@@ -19886,6 +20001,36 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.11.18
+      '@vitest/coverage-v8': 4.0.8(vitest@4.1.5)
+      happy-dom: 20.9.0
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.0.8(vitest@4.1.5))(happy-dom@20.9.0)(jsdom@26.1.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
       '@vitest/coverage-v8': 4.0.8(vitest@4.1.5)
       happy-dom: 20.9.0
       jsdom: 26.1.0


### PR DESCRIPTION
## Summary

- `@winter-love/secret-vault` 패키지 추가: private Git 저장소 기반 시크릿 vault CLI 및 라이브러리 API
- `init`, `add`, `modify`, `import`, `export`, `list`, `sync` 명령 지원 (암호화/평문 저장, namespace, 글로벌 `-n` 옵션)
- 모노레포에서 `pnpm -r exec secret-vault sync`로 패키지별 `.env.local` 동기화 가능
- `vite-lib-config`에 `types` export 추가 (패키지 `vite.config.mts` 타입 해결)

## Test plan

- [ ] `pnpm --filter @winter-love/secret-vault test`
- [ ] `pnpm --filter @winter-love/secret-vault typecheck`
- [ ] `pnpm --filter @winter-love/secret-vault build`
- [ ] `secret-vault init` / `add` / `export` / `sync` 수동 smoke test


Made with [Cursor](https://cursor.com)