### PR TITLE
Streamline Korean writing refinement skill

### DIFF
--- a/.agents/skills/refine-korean-dev-writing/SKILL.md
+++ b/.agents/skills/refine-korean-dev-writing/SKILL.md
@@ -1,150 +1,43 @@
 ---
 name: refine-korean-dev-writing
-description: Refine, draft, or review Korean writing into natural, neutral, and technically precise Korean. Always use whenever Codex or an agent writes, edits, rewrites, summarizes, translates into, reviews, or responds in Korean, including ordinary chat replies and Korean developer-facing text such as code review comments, issue/PR descriptions, commit or release notes, incident notes, developer documentation, Slack-style engineering messages, UI copy, or any technical communication. Preserve the original meaning while removing harsh tone, unclear slang, unnecessary English transliteration, awkward translationese, and ambiguous developer jargon.
+description: Always use when Codex or an agent responds in Korean or writes, edits, summarizes, translates, or reviews Korean text. Refine Korean into natural, neutral, technically clear wording while preserving meaning; remove harsh tone, unclear slang, unnecessary transliteration, translationese, and ambiguous developer jargon. Applies to ordinary chat and developer-facing reviews, issues, PRs, commits, releases, incidents, docs, Slack messages, and UI copy.
 ---
 
 # Refine Korean Dev Writing
 
-## 목적
+## Core Rule
 
-개발자가 작성하거나 Codex·에이전트가 생성하는 한국어 문장을 자연스럽고 명확한 한국어로 정제한다. 의미, 원인, 책임, 장애 정도는 보존하고, 공격적 표현·불필요한 영어 음차·애매한 은어만 중립적이고 구체적인 표현으로 바꾼다.
+Use this skill for every Korean response or Korean text output. Keep the user's meaning intact and make the Korean natural, neutral, concise, and technically clear.
 
-## 적용 대상
+Do not add a visible "refinement" section to ordinary answers. Apply the rules silently unless the user explicitly asks for sentence refinement or comparison.
 
-에이전트가 한국어로 답변하거나 한국어 문장을 작성·수정·요약·번역·검토·출력할 때 항상 적용한다. 사용자가 명시적으로 “문장 정제”를 요청하지 않아도, 일반 채팅 답변과 코드 리뷰, 이슈, PR 설명, 커밋 메시지, 릴리스 노트, 장애 보고, 개발 문서, 팀 채팅 문구, UI 문구처럼 한국어 문장이 포함되면 적용한다.
+## Rules
 
-적용하지 말아야 할 경우:
+- Preserve facts, scope, severity, responsibility, uncertainty, numbers, dates, versions, file paths, identifiers, commands, logs, API names, and error messages.
+- Do not soften real failures: keep bug, regression, outage, incident, security risk, data loss, and ownership clear.
+- Do not add causes, intent, or solutions that the source text does not support.
+- Replace personal judgment with observable code or system behavior.
+- Replace aggressive or blaming tone with neutral, direct wording.
+- Turn accusatory questions into intent checks.
+- Replace unclear developer slang with specific behavior or state.
+- Replace unnecessary English transliteration when Korean is clearer.
+- Keep necessary technical terms, official product names, protocol names, code terms, and team-standard terms.
 
-- 원문이 법무·인사·고객 공지처럼 개발 문맥이 아닌 경우에는 일반 한국어 문장 교정으로 처리한다.
-- 사용자가 예시만 요청하면 파일을 만들거나 수정하지 말고 채팅으로만 답한다.
-- 코드 식별자, 로그 원문, 에러 메시지, API 이름, 명령어는 문장 교정 대상으로 보지 않는다.
+## Quick Mapping
 
-## 작업 순서
+- 왜 이렇게 했나요? -> 이 구현 의도를 확인하고 싶습니다.
+- 핸들링 -> 처리
+- 컨펌 -> 확인 / 승인
+- 워딩 -> 표현 / 문구
+- 박았다 -> 추가했다 / 고정했다 / 하드코딩했다
+- 뻗었다 -> 응답하지 않는다 / 중단되었다
+- 터졌다 -> 실패했다 / 예외가 발생했다 / 장애가 발생했다
+- 이상하게 돈다 -> 의도와 다르게 동작한다
+- 갈아엎다 -> 구조를 크게 변경하다 / 다시 설계하다
+- 배선 -> 연결 / 연결 흐름 / 의존성 연결
 
-1. 원문의 사실, 원인, 영향 범위, 책임 주체, 요청 행동을 분리한다.
-2. 기술적으로 보존할 용어와 고유 표기를 표시한다.
-3. 거친 말투, 불필요한 음차, 은어, 번역투를 찾는다.
-4. 의미가 좁아지거나 넓어지지 않도록 보수적으로 바꾼다.
-5. 출력 전에 의미 보존 규칙을 점검한다.
+## Output
 
-## 문체 규칙
+For normal Korean replies, answer directly in the refined style.
 
-- 기본 문체는 `합니다`체 또는 간결한 서술형으로 쓴다. 원문이 짧은 리뷰 코멘트면 종결어미를 생략해도 된다.
-- 비난 대신 관찰 가능한 현상과 수정 요청을 쓴다.
-- “왜 문제인지”가 필요한 문장은 원인과 영향을 분리해 쓴다.
-- “항상”, “절대”, “완전히” 같은 단정은 원문에 근거가 있을 때만 유지한다.
-- “좋을 것 같습니다”만 반복하지 말고 필요한 행동을 명확히 쓴다.
-- 과하게 공손하게 바꾸지 않는다. 버그, 장애, 회귀, 누락, 책임 주체는 흐리지 않는다.
-- 한국어가 더 명확하면 한국어로 바꾸고, 표준 기술 용어이거나 코드와 맞닿은 용어는 유지한다.
-
-## 금칙어/주의어 사전
-
-| 원문 표현        | 권장 표현                                    | 주의                                                  |
-| ---------------- | -------------------------------------------- | ----------------------------------------------------- |
-| 개판이다         | 구조가 불안정하다 / 동작이 일관되지 않다     | 사람 평가가 아니라 관찰 가능한 현상으로 바꾼다.       |
-| 멍청하게         | 불필요하게 / 의도와 다르게                   | 작성자를 평가하지 않는다.                             |
-| 왜 이렇게 했나요 | 이 구현 의도를 확인하고 싶습니다             | 추궁보다 의도 확인으로 바꾼다.                        |
-| 박았다           | 추가했다 / 고정했다 / 하드코딩했다           | `하드코딩`은 실제 고정값일 때만 쓴다.                 |
-| 갈아엎다         | 구조를 크게 변경하다 / 다시 설계하다         | 변경 범위를 축소하지 않는다.                          |
-| 뻗었다           | 응답하지 않는다 / 중단되었다                 | 상태를 구체화한다.                                    |
-| 터졌다           | 실패했다 / 예외가 발생했다 / 장애가 발생했다 | 장애면 “장애”를 유지한다.                             |
-| 이상하게 돈다    | 의도와 다르게 동작한다                       | 기대 동작이 있으면 함께 제시한다.                     |
-| 핸들링           | 처리                                         | “이벤트 핸들러”처럼 표준 기술 용어인 경우는 유지한다. |
-
-## 치환 예시
-
-- 스타일이 깨져서 → 스타일이 잘못되어
-- 배선 → 연결 / 연결 흐름
-- 컨펌 → 확인 / 승인
-- 워딩 → 표현 / 문구
-- 대충 막아둔 상태 → 임시로 우회 처리한 상태
-
-## 변경 전/후 비교
-
-입력:
-
-```text
-이거 왜 이렇게 박았나요? 상태 배선이 꼬여서 페이지가 이상하게 돕니다.
-```
-
-출력:
-
-```text
-이 값을 고정해 추가한 의도를 확인하고 싶습니다. 상태 연결 흐름이 복잡해져 페이지가 의도와 다르게 동작합니다.
-```
-
-## 의미 보존 규칙
-
-- 원문의 사실, 수치, 날짜, 버전, 범위, 파일명, 함수명, API명, 에러 코드는 바꾸지 않는다.
-- 실패, 장애, 회귀, 보안 취약점, 데이터 손실, 책임 주체는 약하게 만들지 않는다.
-- 추정은 추정으로 유지한다. “일 수 있습니다”를 “입니다”로 단정하지 않는다.
-- 원문에 없는 원인, 의도, 해결책을 추가하지 않는다.
-- 사람을 향한 공격은 제거하되, 코드·시스템의 문제는 명확하게 남긴다.
-- 변경률이 커져 의미가 달라질 가능성이 있으면 더 보수적인 문장으로 다시 쓴다.
-
-## 기술 용어 유지 기준
-
-유지한다:
-
-- 코드 식별자: 함수명, 변수명, 클래스명, 패키지명, 파일 경로
-- 명령어와 옵션: `pnpm test`, `git push`, `--watch`
-- 제품·프로토콜·표준명: React, SolidStart, TypeScript, OAuth, HTTP, GraphQL
-- UI와 API의 공식 명칭: Pull request, Actions, Webhook, Event handler
-- 팀이 공식 용어로 쓰는 단어: 레거시, 마이그레이션, 롤백, 핫픽스 등
-
-바꾼다:
-
-- 한국어가 더 정확한 일반 음차: 핸들링 → 처리, 컨펌 → 확인/승인, 워딩 → 표현/문구
-- 의미가 흐린 은어: 뻗다 → 응답하지 않다/중단되다, 터지다 → 실패하다/예외가 발생하다
-- 과도한 번역투: `~에 대해 처리` → `~을 처리`, `~를 통해 해결` → `~로 해결`
-
-판단이 애매하면 기술 의미 보존을 우선하고, 변경 이유를 짧게 덧붙인다.
-
-## 리뷰 코멘트 변환 규칙
-
-- 사람 평가를 코드 관찰로 바꾼다.
-  - 전: “이 구현은 너무 대충입니다.”
-  - 후: “이 구현은 오류 경로 처리가 부족합니다.”
-- 추궁형 질문을 의도 확인으로 바꾼다.
-  - 전: “왜 여기서 다시 호출하나요?”
-  - 후: “여기서 다시 호출해야 하는 이유를 확인하고 싶습니다.”
-- 장애·회귀 의미는 유지한다.
-  - 전: “이거 때문에 배포가 터졌습니다.”
-  - 후: “이 변경으로 배포가 실패했습니다.”
-
-## 최종 출력 형식
-
-사용자가 단순 정제를 요청하면 아래 형식으로 답한다.
-
-```md
-정제 문장:
-{정제한 문장}
-
-변경 요약:
-
-- {핵심 변경 1}
-- {핵심 변경 2}
-
-보존한 기술 용어:
-
-- `{용어}`: {유지 이유}
-```
-
-여러 문장을 요청하면 표로 답한다.
-
-```md
-| 변경 전 | 변경 후  | 변경 이유   |
-| ------- | -------- | ----------- |
-| {원문}  | {정제문} | {짧은 이유} |
-```
-
-리뷰 코멘트로 바로 붙여 넣을 문장이 필요하면 정제 문장만 출력한다. 사용자가 “설명 없이”라고 요청하면 변경 요약을 생략한다.
-
-## 참고 기준
-
-- DaleSeo korean-skills: 스킬 구조, 한국어 문장 교정의 의미 보존·심각도 기반 접근을 참고한다.
-- Mozilla 한국어 번역 스타일 가이드: 자연스럽고 사용자에게 이해되는 지역화, 기술 용어와 브랜드명 유지 원칙을 참고한다.
-- Microsoft Localization Style Guides - Korean: 한국어 현지화와 기술 문서 용어 기준을 확인할 때 참고한다.
-- GitHub Docs Style Guide: 개발 문서에서 명확하고 포괄적인 표현, 키보드·UI 용어 표기 방식을 참고한다.
-- Google Developer Documentation Style Guide: 개발자를 대상으로 한 명확성, 일관성, 독자 우선 원칙을 참고한다.
-- 국립국어원 다듬은 말: 불필요한 외래어와 음차 표현을 한국어로 바꿀 때 참고하되, 기술 용어 보존 규칙을 우선한다.
+When the user asks to refine text, return only the refined sentence unless they ask for reasons, alternatives, or before/after comparison.


### PR DESCRIPTION
## Summary
- Reevaluate the Korean writing refinement skill and keep it instead of deleting it because the trigger is still needed for Korean agent responses.
- Reduce `SKILL.md` from 150 lines to 43 lines.
- Keep only the minimum rules for meaning preservation, neutral tone, technical terminology, quick mappings, and output behavior.

## Testing
- `python3 /Users/bichi/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/refine-korean-dev-writing`
- `pnpm format`
- `pnpm lint`