### PR TITLE
Add skill diet workflow

### DIFF
--- a/.agents/skills/skill-diet/SKILL.md
+++ b/.agents/skills/skill-diet/SKILL.md
@@ -17,7 +17,7 @@ Repeat until the next deletion would change behavior:
 2. Mark what must survive: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
 3. Delete everything else: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
 4. Re-read the smaller skill as if seeing it for the first time.
-5. Run the smallest available validation. For standard skills, use `quick_validate.py`; for repo changes, also run required format/lint commands.
+5. Run the smallest validation available in the project. For repo changes, also run required format/lint commands.
 
 ## Delete Instead
 

--- a/.agents/skills/skill-diet/SKILL.md
+++ b/.agents/skills/skill-diet/SKILL.md
@@ -17,7 +17,7 @@ Repeat until the next deletion would change behavior:
 2. Mark what must survive: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
 3. Delete everything else: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
 4. Re-read the smaller skill as if seeing it for the first time.
-5. Run the smallest validation available in the project. For repo changes, also run required format/lint commands.
+5. Run the smallest validation available. If this skill's script is available, run `node scripts/validate-skill.js <skill_directory>`. For repo changes, also run required format/lint commands.
 
 ## Delete Instead
 

--- a/.agents/skills/skill-diet/SKILL.md
+++ b/.agents/skills/skill-diet/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: skill-diet
+description: Reduce an existing Codex skill to its minimum useful form, or decide that the skill should be deleted. Use when the user asks to diet, slim, trim, simplify, minimize, reevaluate, or remove bloat from a skill while preserving its trigger behavior, tone, safety constraints, and practical usefulness.
+---
+
+# Skill Diet
+
+## Goal
+
+Shrink a skill until only durable behavior remains. Prefer deletion when the skill only repeats general model ability, AGENTS.md rules, or non-actionable advice.
+
+## Loop
+
+Repeat until the next deletion would change behavior:
+
+1. Name the skill's real job in one sentence.
+2. Mark what must survive: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
+3. Delete everything else: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
+4. Re-read the smaller skill as if seeing it for the first time.
+5. Run the smallest available validation. For standard skills, use `quick_validate.py`; for repo changes, also run required format/lint commands.
+
+## Delete Instead
+
+Delete the skill if all are true:
+
+- No durable trigger is needed.
+- No project- or domain-specific rule remains.
+- No reusable resource routing remains.
+- The remaining behavior is already covered by system, developer, AGENTS.md, or normal model ability.
+
+When deleting, remove the whole skill folder and state the reason.
+
+## Keep
+
+Keep only rules that prevent a likely future mistake. Keep examples only when they define a boundary the model may otherwise miss.
+
+## Output
+
+Report:
+
+- decision: kept, reduced, or deleted
+- before/after size
+- what stayed and why
+- validation run

--- a/.agents/skills/skill-diet/agents/openai.yaml
+++ b/.agents/skills/skill-diet/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: '스킬 다이어트'
+  short_description: 'Bloated skills reduced to minimal useful rules'
+  default_prompt: 'Use $skill-diet to reduce a skill to its minimum useful form.'

--- a/.agents/skills/skill-diet/scripts/__tests__/validate-skill-core.spec.ts
+++ b/.agents/skills/skill-diet/scripts/__tests__/validate-skill-core.spec.ts
@@ -1,0 +1,207 @@
+import {mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, describe, expect, it} from 'vitest'
+import {validateSkillContent, validateSkillDirectory} from '../validate-skill-core.js'
+
+const TEMP_PREFIX = 'skill-validator-core-'
+
+const tempDirectories: string[] = []
+
+describe('validateSkillContent', () => {
+  it('should accept valid skill frontmatter', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: Keep this skill small and useful.
+---
+
+# Valid Skill
+`),
+    ).not.toThrow()
+  })
+
+  it('should accept project-specific optional frontmatter keys', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: Keep this skill small and useful.
+argument-hint: '<skill>'
+compatibility:
+  codex: true
+disable-model-invocation: true
+metadata:
+  owner: docs
+---
+`),
+    ).not.toThrow()
+  })
+
+  it('should reject content without YAML frontmatter', () => {
+    expect(() => validateSkillContent('# Skill')).toThrow('No YAML frontmatter found')
+  })
+
+  it('should reject incomplete frontmatter', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: Keep this skill small and useful.
+`),
+    ).toThrow('Invalid frontmatter format')
+  })
+
+  it('should reject unknown frontmatter keys', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: Keep this skill small and useful.
+unknown: value
+---
+`),
+    ).toThrow('Unexpected key(s) in SKILL.md frontmatter: unknown.')
+  })
+
+  it('should reject missing name', () => {
+    expect(() =>
+      validateSkillContent(`---
+description: Keep this skill small and useful.
+---
+`),
+    ).toThrow("Missing 'name' in frontmatter")
+  })
+
+  it('should reject missing description', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+---
+`),
+    ).toThrow("Missing 'description' in frontmatter")
+  })
+
+  it('should reject invalid skill names', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: Invalid Skill
+description: Keep this skill small and useful.
+---
+`),
+    ).toThrow("Name 'Invalid Skill' should be hyphen-case")
+  })
+
+  it('should reject names with consecutive hyphens', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: invalid--skill
+description: Keep this skill small and useful.
+---
+`),
+    ).toThrow("Name 'invalid--skill' cannot start/end with hyphen or contain consecutive hyphens")
+  })
+
+  it('should reject long names', () => {
+    const longName = 'a'.repeat(65)
+
+    expect(() =>
+      validateSkillContent(`---
+name: ${longName}
+description: Keep this skill small and useful.
+---
+`),
+    ).toThrow('Name is too long (65 characters). Maximum is 64 characters.')
+  })
+
+  it('should reject descriptions with angle brackets', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: Use <placeholder> text.
+---
+`),
+    ).toThrow('Description cannot contain angle brackets (< or >)')
+  })
+
+  it('should reject long descriptions', () => {
+    const longDescription = 'a'.repeat(1025)
+
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: ${longDescription}
+---
+`),
+    ).toThrow('Description is too long (1025 characters). Maximum is 1024 characters.')
+  })
+
+  it('should reject inline YAML collections', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: [invalid]
+---
+`),
+    ).toThrow('Inline YAML collections are not supported by this validator')
+  })
+
+  it('should reject invalid frontmatter lines', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description
+---
+`),
+    ).toThrow('Invalid frontmatter line: description')
+  })
+
+  it('should parse block descriptions', () => {
+    expect(() =>
+      validateSkillContent(`---
+name: valid-skill
+description: >
+  Keep this skill small
+  and useful.
+---
+`),
+    ).not.toThrow()
+  })
+})
+
+describe('validateSkillDirectory', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirectories.splice(0).map((directory) => rm(directory, {force: true, recursive: true})),
+    )
+  })
+
+  it('should read and validate SKILL.md from a skill directory', async () => {
+    const directory = await createSkill(`---
+name: valid-skill
+description: Keep this skill small and useful.
+---
+`)
+
+    expect(() => validateSkillDirectory(directory)).not.toThrow()
+  })
+
+  it('should reject a missing SKILL.md file', async () => {
+    const directory = await createTempDirectory()
+
+    expect(() => validateSkillDirectory(directory)).toThrow('SKILL.md not found')
+  })
+})
+
+async function createSkill(content: string) {
+  const directory = await createTempDirectory()
+
+  await writeFile(join(directory, 'SKILL.md'), content)
+
+  return directory
+}
+
+async function createTempDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), TEMP_PREFIX))
+
+  tempDirectories.push(directory)
+
+  return directory
+}

--- a/.agents/skills/skill-diet/scripts/__tests__/validate-skill.spec.ts
+++ b/.agents/skills/skill-diet/scripts/__tests__/validate-skill.spec.ts
@@ -1,0 +1,159 @@
+import {spawn} from 'node:child_process'
+import {mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, describe, expect, it} from 'vitest'
+
+const SCRIPT_PATH = join(process.cwd(), '.agents/skills/skill-diet/scripts/validate-skill.js')
+const TEMP_PREFIX = 'skill-validator-'
+const SUCCESS_EXIT_CODE = 0
+const FAILURE_EXIT_CODE = 1
+
+const tempDirectories: string[] = []
+
+interface CommandResult {
+  readonly code: number | null
+  readonly stderr: string
+  readonly stdout: string
+}
+
+describe('validate-skill', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirectories.splice(0).map((directory) => rm(directory, {force: true, recursive: true})),
+    )
+  })
+
+  it('should accept a valid skill frontmatter', async () => {
+    const skillDirectory = await createSkill(`---
+name: valid-skill
+description: Keep this skill small and useful.
+---
+
+# Valid Skill
+`)
+
+    const result = await runValidator(skillDirectory)
+
+    expect(result).toEqual({
+      code: SUCCESS_EXIT_CODE,
+      stderr: '',
+      stdout: 'Skill is valid!\n',
+    })
+  })
+
+  it('should print usage when the skill directory is missing', async () => {
+    const result = await runValidator()
+
+    expect(result).toEqual({
+      code: FAILURE_EXIT_CODE,
+      stderr: 'Usage: node scripts/validate-skill.js <skill_directory>\n',
+      stdout: '',
+    })
+  })
+
+  it('should reject a missing SKILL.md file', async () => {
+    const skillDirectory = await createTempDirectory()
+
+    const result = await runValidator(skillDirectory)
+
+    expect(result).toMatchObject({
+      code: FAILURE_EXIT_CODE,
+      stderr: 'SKILL.md not found\n',
+    })
+  })
+
+  it('should reject unknown frontmatter keys', async () => {
+    const skillDirectory = await createSkill(`---
+name: valid-skill
+description: Keep this skill small and useful.
+unknown: value
+---
+`)
+
+    const result = await runValidator(skillDirectory)
+
+    expect(result).toMatchObject({
+      code: FAILURE_EXIT_CODE,
+    })
+    expect(result.stderr).toContain('Unexpected key(s) in SKILL.md frontmatter: unknown.')
+  })
+
+  it('should reject invalid skill names', async () => {
+    const skillDirectory = await createSkill(`---
+name: Invalid Skill
+description: Keep this skill small and useful.
+---
+`)
+
+    const result = await runValidator(skillDirectory)
+
+    expect(result).toMatchObject({
+      code: FAILURE_EXIT_CODE,
+      stderr:
+        "Name 'Invalid Skill' should be hyphen-case (lowercase letters, digits, and hyphens only)\n",
+    })
+  })
+
+  it('should reject descriptions with angle brackets', async () => {
+    const skillDirectory = await createSkill(`---
+name: valid-skill
+description: Use <placeholder> text.
+---
+`)
+
+    const result = await runValidator(skillDirectory)
+
+    expect(result).toMatchObject({
+      code: FAILURE_EXIT_CODE,
+      stderr: 'Description cannot contain angle brackets (< or >)\n',
+    })
+  })
+})
+
+async function createSkill(content: string) {
+  const directory = await createTempDirectory()
+
+  await writeFile(join(directory, 'SKILL.md'), content)
+
+  return directory
+}
+
+async function createTempDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), TEMP_PREFIX))
+
+  tempDirectories.push(directory)
+
+  return directory
+}
+
+async function runValidator(skillDirectory?: string): Promise<CommandResult> {
+  const args = skillDirectory ? [SCRIPT_PATH, skillDirectory] : [SCRIPT_PATH]
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+
+    child.on('close', (code) => {
+      resolve({
+        code,
+        stderr,
+        stdout,
+      })
+    })
+  })
+}

--- a/.agents/skills/skill-diet/scripts/__tests__/validate-skill.spec.ts
+++ b/.agents/skills/skill-diet/scripts/__tests__/validate-skill.spec.ts
@@ -51,64 +51,6 @@ description: Keep this skill small and useful.
       stdout: '',
     })
   })
-
-  it('should reject a missing SKILL.md file', async () => {
-    const skillDirectory = await createTempDirectory()
-
-    const result = await runValidator(skillDirectory)
-
-    expect(result).toMatchObject({
-      code: FAILURE_EXIT_CODE,
-      stderr: 'SKILL.md not found\n',
-    })
-  })
-
-  it('should reject unknown frontmatter keys', async () => {
-    const skillDirectory = await createSkill(`---
-name: valid-skill
-description: Keep this skill small and useful.
-unknown: value
----
-`)
-
-    const result = await runValidator(skillDirectory)
-
-    expect(result).toMatchObject({
-      code: FAILURE_EXIT_CODE,
-    })
-    expect(result.stderr).toContain('Unexpected key(s) in SKILL.md frontmatter: unknown.')
-  })
-
-  it('should reject invalid skill names', async () => {
-    const skillDirectory = await createSkill(`---
-name: Invalid Skill
-description: Keep this skill small and useful.
----
-`)
-
-    const result = await runValidator(skillDirectory)
-
-    expect(result).toMatchObject({
-      code: FAILURE_EXIT_CODE,
-      stderr:
-        "Name 'Invalid Skill' should be hyphen-case (lowercase letters, digits, and hyphens only)\n",
-    })
-  })
-
-  it('should reject descriptions with angle brackets', async () => {
-    const skillDirectory = await createSkill(`---
-name: valid-skill
-description: Use <placeholder> text.
----
-`)
-
-    const result = await runValidator(skillDirectory)
-
-    expect(result).toMatchObject({
-      code: FAILURE_EXIT_CODE,
-      stderr: 'Description cannot contain angle brackets (< or >)\n',
-    })
-  })
 })
 
 async function createSkill(content: string) {

--- a/.agents/skills/skill-diet/scripts/validate-skill-core.js
+++ b/.agents/skills/skill-diet/scripts/validate-skill-core.js
@@ -1,0 +1,214 @@
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+const MAX_NAME_LENGTH = 64
+const MAX_DESCRIPTION_LENGTH = 1024
+const FRONTMATTER_START = '---\n'
+const FRONTMATTER_END = '\n---'
+const ALLOWED_KEYS = new Set([
+  'name',
+  'description',
+  'license',
+  'allowed-tools',
+  'metadata',
+  'argument-hint',
+  'compatibility',
+  'disable-model-invocation',
+])
+const FRONTMATTER_LINE_PATTERN = /^(?<key>[A-Za-z0-9_-]+):(?:\s*(?<value>.*))?$/u
+const INDENTED_LINE_PATTERN = /^\s+/u
+const FRONTMATTER_CHILD_LINE_PATTERN = /^(?:\s+|$)/u
+const TWO_SPACE_INDENT_PATTERN = /^\s{2}/u
+const SKILL_NAME_PATTERN = /^[a-z0-9-]+$/u
+
+export function validateSkillDirectory(skillDirectory) {
+  const skillPath = resolve(skillDirectory)
+  const skillMdPath = resolve(skillPath, 'SKILL.md')
+
+  try {
+    validateSkillContent(readFileSync(skillMdPath, 'utf8'))
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error('SKILL.md not found')
+    }
+
+    throw error
+  }
+}
+
+export function validateSkillContent(content) {
+  if (!content.startsWith(FRONTMATTER_START)) {
+    throw new Error('No YAML frontmatter found')
+  }
+
+  const frontmatterEndIndex = content.indexOf(FRONTMATTER_END, FRONTMATTER_START.length)
+
+  if (frontmatterEndIndex === -1) {
+    throw new Error('Invalid frontmatter format')
+  }
+
+  const frontmatterText = content.slice(FRONTMATTER_START.length, frontmatterEndIndex)
+  const frontmatter = parseFrontmatter(frontmatterText)
+  const unexpectedKeys = Object.keys(frontmatter).filter((key) => !ALLOWED_KEYS.has(key))
+
+  if (unexpectedKeys.length > 0) {
+    const allowedProperties = [...ALLOWED_KEYS].sort().join(', ')
+
+    throw new Error(
+      `Unexpected key(s) in SKILL.md frontmatter: ${unexpectedKeys.join(', ')}. ` +
+        `Allowed properties are: ${allowedProperties}`,
+    )
+  }
+
+  if (!Object.hasOwn(frontmatter, 'name')) {
+    throw new Error("Missing 'name' in frontmatter")
+  }
+
+  if (!Object.hasOwn(frontmatter, 'description')) {
+    throw new Error("Missing 'description' in frontmatter")
+  }
+
+  validateName(frontmatter.name)
+  validateDescription(frontmatter.description)
+}
+
+function parseFrontmatter(text) {
+  const result = {}
+  const lines = text.split('\n')
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (shouldParseLine(line)) {
+      const match = FRONTMATTER_LINE_PATTERN.exec(line)
+
+      if (!match?.groups) {
+        throw new Error(`Invalid frontmatter line: ${line}`)
+      }
+
+      index = parseFrontmatterLine({index, lines, match, result})
+    }
+  }
+
+  return result
+}
+
+function shouldParseLine(line) {
+  return line.trim() !== '' && !line.trimStart().startsWith('#')
+}
+
+function parseFrontmatterLine({index, lines, match, result}) {
+  const {key, value = ''} = match.groups
+  const rawValue = value
+
+  if (
+    rawValue.trim() === '' &&
+    index + 1 < lines.length &&
+    INDENTED_LINE_PATTERN.test(lines[index + 1])
+  ) {
+    return parseChildLines({index, key, lines, result})
+  }
+
+  if (rawValue === '|' || rawValue === '>') {
+    return parseBlockValue({index, key, lines, rawValue, result})
+  }
+
+  result[key] = normalizeScalar(rawValue)
+
+  return index
+}
+
+function parseChildLines({index, key, lines, result}) {
+  let nextIndex = index
+
+  while (
+    nextIndex + 1 < lines.length &&
+    FRONTMATTER_CHILD_LINE_PATTERN.test(lines[nextIndex + 1])
+  ) {
+    nextIndex += 1
+  }
+
+  result[key] = {}
+
+  return nextIndex
+}
+
+function parseBlockValue({index, key, lines, result, rawValue}) {
+  const blockLines = []
+  let nextIndex = index
+
+  while (
+    nextIndex + 1 < lines.length &&
+    FRONTMATTER_CHILD_LINE_PATTERN.test(lines[nextIndex + 1])
+  ) {
+    nextIndex += 1
+    blockLines.push(lines[nextIndex].replace(TWO_SPACE_INDENT_PATTERN, ''))
+  }
+
+  result[key] = blockLines.join(rawValue === '>' ? ' ' : '\n').trim()
+
+  return nextIndex
+}
+
+function normalizeScalar(value) {
+  const trimmedValue = value.trim()
+
+  if (
+    (trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
+    (trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+  ) {
+    return trimmedValue.slice(1, -1)
+  }
+
+  if (trimmedValue === '') {
+    return ''
+  }
+
+  if (trimmedValue.startsWith('[') || trimmedValue.startsWith('{')) {
+    throw new Error('Inline YAML collections are not supported by this validator')
+  }
+
+  return trimmedValue
+}
+
+function validateName(value) {
+  if (typeof value !== 'string') {
+    throw new Error(`Name must be a string, got ${typeof value}`)
+  }
+
+  const name = value.trim()
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Name '${name}' should be hyphen-case (lowercase letters, digits, and hyphens only)`,
+    )
+  }
+
+  if (name.startsWith('-') || name.endsWith('-') || name.includes('--')) {
+    throw new Error(`Name '${name}' cannot start/end with hyphen or contain consecutive hyphens`)
+  }
+
+  if (name.length > MAX_NAME_LENGTH) {
+    throw new Error(
+      `Name is too long (${name.length} characters). Maximum is ${MAX_NAME_LENGTH} characters.`,
+    )
+  }
+}
+
+function validateDescription(value) {
+  if (typeof value !== 'string') {
+    throw new Error(`Description must be a string, got ${typeof value}`)
+  }
+
+  const description = value.trim()
+
+  if (description.includes('<') || description.includes('>')) {
+    throw new Error('Description cannot contain angle brackets (< or >)')
+  }
+
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    throw new Error(
+      `Description is too long (${description.length} characters). Maximum is ${MAX_DESCRIPTION_LENGTH} characters.`,
+    )
+  }
+}

--- a/.agents/skills/skill-diet/scripts/validate-skill.js
+++ b/.agents/skills/skill-diet/scripts/validate-skill.js
@@ -1,27 +1,6 @@
 #!/usr/bin/env node
 
-import {readFileSync} from 'node:fs'
-import {resolve} from 'node:path'
-
-const MAX_NAME_LENGTH = 64
-const MAX_DESCRIPTION_LENGTH = 1024
-const FRONTMATTER_START = '---\n'
-const FRONTMATTER_END = '\n---'
-const ALLOWED_KEYS = new Set([
-  'name',
-  'description',
-  'license',
-  'allowed-tools',
-  'metadata',
-  'argument-hint',
-  'compatibility',
-  'disable-model-invocation',
-])
-const FRONTMATTER_LINE_PATTERN = /^(?<key>[A-Za-z0-9_-]+):(?:\s*(?<value>.*))?$/u
-const INDENTED_LINE_PATTERN = /^\s+/u
-const FRONTMATTER_CHILD_LINE_PATTERN = /^(?:\s+|$)/u
-const TWO_SPACE_INDENT_PATTERN = /^\s{2}/u
-const SKILL_NAME_PATTERN = /^[a-z0-9-]+$/u
+import {validateSkillDirectory} from './validate-skill-core.js'
 
 const [, , skillDirectory] = process.argv
 
@@ -29,155 +8,11 @@ if (!skillDirectory) {
   fail('Usage: node scripts/validate-skill.js <skill_directory>')
 }
 
-const skillPath = resolve(skillDirectory)
-const skillMdPath = resolve(skillPath, 'SKILL.md')
-
-let content = ''
-
 try {
-  content = readFileSync(skillMdPath, 'utf8')
-} catch {
-  fail('SKILL.md not found')
-}
-
-if (!content.startsWith(FRONTMATTER_START)) {
-  fail('No YAML frontmatter found')
-}
-
-const frontmatterEndIndex = content.indexOf(FRONTMATTER_END, FRONTMATTER_START.length)
-
-if (frontmatterEndIndex === -1) {
-  fail('Invalid frontmatter format')
-}
-
-const frontmatterText = content.slice(FRONTMATTER_START.length, frontmatterEndIndex)
-const frontmatter = parseFrontmatter(frontmatterText)
-const unexpectedKeys = Object.keys(frontmatter).filter((key) => !ALLOWED_KEYS.has(key))
-
-if (unexpectedKeys.length > 0) {
-  const allowedProperties = [...ALLOWED_KEYS].sort().join(', ')
-
-  fail(
-    `Unexpected key(s) in SKILL.md frontmatter: ${unexpectedKeys.join(', ')}. ` +
-      `Allowed properties are: ${allowedProperties}`,
-  )
-}
-
-if (!Object.hasOwn(frontmatter, 'name')) {
-  fail("Missing 'name' in frontmatter")
-}
-
-if (!Object.hasOwn(frontmatter, 'description')) {
-  fail("Missing 'description' in frontmatter")
-}
-
-validateName(frontmatter.name)
-validateDescription(frontmatter.description)
-
-console.log('Skill is valid!')
-
-function parseFrontmatter(text) {
-  const result = {}
-  const lines = text.split('\n')
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]
-
-    if (line.trim() !== '' && !line.trimStart().startsWith('#')) {
-      const match = FRONTMATTER_LINE_PATTERN.exec(line)
-
-      if (!match?.groups) {
-        fail(`Invalid frontmatter line: ${line}`)
-      }
-
-      const {key, value = ''} = match.groups
-      const rawValue = value
-
-      if (
-        rawValue.trim() === '' &&
-        index + 1 < lines.length &&
-        INDENTED_LINE_PATTERN.test(lines[index + 1])
-      ) {
-        while (index + 1 < lines.length && FRONTMATTER_CHILD_LINE_PATTERN.test(lines[index + 1])) {
-          index += 1
-        }
-
-        result[key] = {}
-      } else if (rawValue === '|' || rawValue === '>') {
-        const blockLines = []
-
-        while (index + 1 < lines.length && FRONTMATTER_CHILD_LINE_PATTERN.test(lines[index + 1])) {
-          index += 1
-          blockLines.push(lines[index].replace(TWO_SPACE_INDENT_PATTERN, ''))
-        }
-
-        result[key] = blockLines.join(rawValue === '>' ? ' ' : '\n').trim()
-      } else {
-        result[key] = normalizeScalar(rawValue)
-      }
-    }
-  }
-
-  return result
-}
-
-function normalizeScalar(value) {
-  const trimmedValue = value.trim()
-
-  if (
-    (trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
-    (trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
-  ) {
-    return trimmedValue.slice(1, -1)
-  }
-
-  if (trimmedValue === '') {
-    return ''
-  }
-
-  if (trimmedValue.startsWith('[') || trimmedValue.startsWith('{')) {
-    fail('Inline YAML collections are not supported by this validator')
-  }
-
-  return trimmedValue
-}
-
-function validateName(value) {
-  if (typeof value !== 'string') {
-    fail(`Name must be a string, got ${typeof value}`)
-  }
-
-  const name = value.trim()
-
-  if (!SKILL_NAME_PATTERN.test(name)) {
-    fail(`Name '${name}' should be hyphen-case (lowercase letters, digits, and hyphens only)`)
-  }
-
-  if (name.startsWith('-') || name.endsWith('-') || name.includes('--')) {
-    fail(`Name '${name}' cannot start/end with hyphen or contain consecutive hyphens`)
-  }
-
-  if (name.length > MAX_NAME_LENGTH) {
-    fail(`Name is too long (${name.length} characters). Maximum is ${MAX_NAME_LENGTH} characters.`)
-  }
-}
-
-function validateDescription(value) {
-  if (typeof value !== 'string') {
-    fail(`Description must be a string, got ${typeof value}`)
-  }
-
-  const description = value.trim()
-
-  if (description.includes('<') || description.includes('>')) {
-    fail('Description cannot contain angle brackets (< or >)')
-  }
-
-  if (description.length > MAX_DESCRIPTION_LENGTH) {
-    fail(
-      `Description is too long (${description.length} characters). Maximum is ${MAX_DESCRIPTION_LENGTH} characters.`,
-    )
-  }
+  validateSkillDirectory(skillDirectory)
+  console.log('Skill is valid!')
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
 }
 
 function fail(message) {

--- a/.agents/skills/skill-diet/scripts/validate-skill.js
+++ b/.agents/skills/skill-diet/scripts/validate-skill.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+const MAX_NAME_LENGTH = 64
+const MAX_DESCRIPTION_LENGTH = 1024
+const FRONTMATTER_START = '---\n'
+const FRONTMATTER_END = '\n---'
+const ALLOWED_KEYS = new Set([
+  'name',
+  'description',
+  'license',
+  'allowed-tools',
+  'metadata',
+  'argument-hint',
+  'compatibility',
+  'disable-model-invocation',
+])
+const FRONTMATTER_LINE_PATTERN = /^(?<key>[A-Za-z0-9_-]+):(?:\s*(?<value>.*))?$/u
+const INDENTED_LINE_PATTERN = /^\s+/u
+const FRONTMATTER_CHILD_LINE_PATTERN = /^(?:\s+|$)/u
+const TWO_SPACE_INDENT_PATTERN = /^\s{2}/u
+const SKILL_NAME_PATTERN = /^[a-z0-9-]+$/u
+
+const [, , skillDirectory] = process.argv
+
+if (!skillDirectory) {
+  fail('Usage: node scripts/validate-skill.js <skill_directory>')
+}
+
+const skillPath = resolve(skillDirectory)
+const skillMdPath = resolve(skillPath, 'SKILL.md')
+
+let content = ''
+
+try {
+  content = readFileSync(skillMdPath, 'utf8')
+} catch {
+  fail('SKILL.md not found')
+}
+
+if (!content.startsWith(FRONTMATTER_START)) {
+  fail('No YAML frontmatter found')
+}
+
+const frontmatterEndIndex = content.indexOf(FRONTMATTER_END, FRONTMATTER_START.length)
+
+if (frontmatterEndIndex === -1) {
+  fail('Invalid frontmatter format')
+}
+
+const frontmatterText = content.slice(FRONTMATTER_START.length, frontmatterEndIndex)
+const frontmatter = parseFrontmatter(frontmatterText)
+const unexpectedKeys = Object.keys(frontmatter).filter((key) => !ALLOWED_KEYS.has(key))
+
+if (unexpectedKeys.length > 0) {
+  const allowedProperties = [...ALLOWED_KEYS].sort().join(', ')
+
+  fail(
+    `Unexpected key(s) in SKILL.md frontmatter: ${unexpectedKeys.join(', ')}. ` +
+      `Allowed properties are: ${allowedProperties}`,
+  )
+}
+
+if (!Object.hasOwn(frontmatter, 'name')) {
+  fail("Missing 'name' in frontmatter")
+}
+
+if (!Object.hasOwn(frontmatter, 'description')) {
+  fail("Missing 'description' in frontmatter")
+}
+
+validateName(frontmatter.name)
+validateDescription(frontmatter.description)
+
+console.log('Skill is valid!')
+
+function parseFrontmatter(text) {
+  const result = {}
+  const lines = text.split('\n')
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (line.trim() !== '' && !line.trimStart().startsWith('#')) {
+      const match = FRONTMATTER_LINE_PATTERN.exec(line)
+
+      if (!match?.groups) {
+        fail(`Invalid frontmatter line: ${line}`)
+      }
+
+      const {key, value = ''} = match.groups
+      const rawValue = value
+
+      if (
+        rawValue.trim() === '' &&
+        index + 1 < lines.length &&
+        INDENTED_LINE_PATTERN.test(lines[index + 1])
+      ) {
+        while (index + 1 < lines.length && FRONTMATTER_CHILD_LINE_PATTERN.test(lines[index + 1])) {
+          index += 1
+        }
+
+        result[key] = {}
+      } else if (rawValue === '|' || rawValue === '>') {
+        const blockLines = []
+
+        while (index + 1 < lines.length && FRONTMATTER_CHILD_LINE_PATTERN.test(lines[index + 1])) {
+          index += 1
+          blockLines.push(lines[index].replace(TWO_SPACE_INDENT_PATTERN, ''))
+        }
+
+        result[key] = blockLines.join(rawValue === '>' ? ' ' : '\n').trim()
+      } else {
+        result[key] = normalizeScalar(rawValue)
+      }
+    }
+  }
+
+  return result
+}
+
+function normalizeScalar(value) {
+  const trimmedValue = value.trim()
+
+  if (
+    (trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
+    (trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+  ) {
+    return trimmedValue.slice(1, -1)
+  }
+
+  if (trimmedValue === '') {
+    return ''
+  }
+
+  if (trimmedValue.startsWith('[') || trimmedValue.startsWith('{')) {
+    fail('Inline YAML collections are not supported by this validator')
+  }
+
+  return trimmedValue
+}
+
+function validateName(value) {
+  if (typeof value !== 'string') {
+    fail(`Name must be a string, got ${typeof value}`)
+  }
+
+  const name = value.trim()
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    fail(`Name '${name}' should be hyphen-case (lowercase letters, digits, and hyphens only)`)
+  }
+
+  if (name.startsWith('-') || name.endsWith('-') || name.includes('--')) {
+    fail(`Name '${name}' cannot start/end with hyphen or contain consecutive hyphens`)
+  }
+
+  if (name.length > MAX_NAME_LENGTH) {
+    fail(`Name is too long (${name.length} characters). Maximum is ${MAX_NAME_LENGTH} characters.`)
+  }
+}
+
+function validateDescription(value) {
+  if (typeof value !== 'string') {
+    fail(`Description must be a string, got ${typeof value}`)
+  }
+
+  const description = value.trim()
+
+  if (description.includes('<') || description.includes('>')) {
+    fail('Description cannot contain angle brackets (< or >)')
+  }
+
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    fail(
+      `Description is too long (${description.length} characters). Maximum is ${MAX_DESCRIPTION_LENGTH} characters.`,
+    )
+  }
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}

--- a/.agents/skills/unit-test/SKILL.md
+++ b/.agents/skills/unit-test/SKILL.md
@@ -13,7 +13,7 @@ Open and apply the reference files for the relevant section before working.
 2. Use Vitest, and use `@solidjs/testing-library` for Solid.js DOM tests.
 3. Place tests in the target directory's `__tests__` folder and name files `{targetFileName}.spec.ts`.
 4. Start test names with `should`, and split multi-function targets with `describe` blocks.
-5. Do not modify the code under test; if a production change is required, explain why instead of changing it.
+5. Do not modify the code under test by default. If the target is hard to unit test because logic is embedded in CLI, UI, I/O, or lifecycle code, ask whether to first extract the behavior into pure, importable logic functions, then test those functions and keep only smoke coverage for the wrapper.
 6. For DOM tests, add `/** @vitest-environment jsdom */` at the top of the file.
 7. Aim for 100% coverage; when impossible, add ignore comments and document the reason.
 8. Verify tests and coverage after changes, then fix lint issues.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -31,7 +31,11 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    include: ['packages/*/src/**/*.spec.?(c|m)[jt]s?(x)', 'apps/*/src/**/*.spec.?(c|m)[jt]s?(x)'],
+    include: [
+      'packages/*/src/**/*.spec.?(c|m)[jt]s?(x)',
+      'apps/*/src/**/*.spec.?(c|m)[jt]s?(x)',
+      '.agents/skills/*/scripts/**/*.spec.ts',
+    ],
     setupFiles: ['./vitest.setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- Add a `skill-diet` Codex skill for reducing bloated skills to their minimum useful form.
- Include a repeatable reduction loop, deletion criteria, keep criteria, and reporting format.
- Add a Node.js validator for minimum skill frontmatter checks without relying on Codex's Python validator.
- Split validator logic into `validate-skill-core.js` so rules can be tested directly, while `validate-skill.js` stays as a thin CLI wrapper.
- Add Vitest coverage for the validator core and CLI smoke paths, and include skill script specs in the root Vitest config.
- Update the `unit-test` skill to ask before refactoring hard-to-test CLI, UI, I/O, or lifecycle code into pure importable logic functions.

## Testing
- `find .agents/skills -mindepth 1 -maxdepth 1 -type d -exec node .agents/skills/skill-diet/scripts/validate-skill.js {} \\;`
- `node .agents/skills/skill-diet/scripts/validate-skill.js`
- `node .agents/skills/skill-diet/scripts/validate-skill.js .agents/skills/unit-test`
- `rg -n "quick_validate\\.py|quick_validate" .agents/skills`
- `pnpm vitest run .agents/skills/skill-diet/scripts/__tests__/validate-skill.spec.ts .agents/skills/skill-diet/scripts/__tests__/validate-skill-core.spec.ts --reporter=dot`
- `pnpm format`
- `pnpm lint`
- `pnpm test` (fails on existing `apps/coong/src/components/select-menu/__tests__/use-select-menu.spec.ts`: expected anchor rect, received `{}`)