### PR TITLE
Document latest dev base for new worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@
 
 **Enterprise-grade** code: maintainability, scalability, separation of concerns, robust error handling, consistent patterns.
 
+## Worktree initialization
+
+- Start new worktrees from the latest `origin/dev` commit.
+- Do not automatically merge, rebase, or reset an existing worktree with in-progress changes.
+
 ## Required after changes
 
 1. Fix oxlint errors


### PR DESCRIPTION
## Summary

- Require new worktrees to start from the latest `origin/dev` commit
- Preserve existing worktrees by prohibiting automatic merge, rebase, or reset

## Testing

- `pnpm lint` (passes with 27 existing warnings)
- `pnpm format`