### PR TITLE
Document GitHub Keychain authentication retry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Chat context is volatile. When **why** isn't obvious from code, leave a minimal 
 - Content: decision + reason (constraints, rejected approach, non-obvious tradeoff); not a changelog
 - Scope: cross-session gaps only; skip self-explanatory code
 
+## GitHub CLI authentication
+
+- `gh` credentials are stored in the macOS Keychain and may appear invalid in the default sandbox.
+- If `gh auth status` fails in the sandbox, retry the command with escalated permissions before asking the user to authenticate again.
+- Ask the user to run `gh auth login` only when authentication also fails with escalated permissions.
+
 ## Cursor Cloud
 
 pnpm + Turborepo (`@winter-love/web`) · Node ≥22 · pnpm 10.x (`package.json`). `pnpm install` runs workspace `prepare` (package builds; Coong Supabase type gen).


### PR DESCRIPTION
## Summary

- Document that GitHub CLI credentials use the macOS Keychain.
- Require an escalated authentication retry before asking users to log in again.

## Testing

- `pnpm format`
- `pnpm lint` (0 errors; 27 existing warnings)