### PR TITLE
chore - add Cursor worktree setup to copy Coong .env

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,6 @@
+{
+  "setup-worktree": [
+    "cp \"$ROOT_WORKTREE_PATH/apps/coong/.env\" apps/coong/.env",
+    "pnpm install"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.cursor/worktrees.json` so Cursor worktree setup copies `apps/coong/.env` from the root checkout, then runs `pnpm install`

## Test plan
- [ ] Create a Cursor worktree from this repo and confirm Output → Worktrees Setup runs the copy + install steps
- [ ] Verify `apps/coong/.env` exists in the new worktree and matches the root checkout


Made with [Cursor](https://cursor.com)