### PR TITLE
Copy Coong env into Codex worktrees

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,6 +8,10 @@ script = "cd "
 [setup.darwin]
 script = '''
 cd "$CODEX_WORKTREE_PATH"
+REPOSITORY_PATH="$(dirname "$(git rev-parse --git-common-dir)")"
+if [ -f "$REPOSITORY_PATH/apps/coong/.env" ]; then
+  cp "$REPOSITORY_PATH/apps/coong/.env" apps/coong/.env
+fi
 pnpm install
 git config user.name "kimbichi"
 git config user.email "bichi@live.co.kr"


### PR DESCRIPTION
## Summary

- Copy the existing Coong `.env` into newly initialized Codex worktrees.
- Skip the copy when the source `.env` does not exist.

## Testing

- `pnpm format`
- `pnpm lint` (0 errors, 27 existing warnings)
- Verified the source path resolves to the main repository's `apps/coong/.env`.