### PR TITLE
chore: harden Cursor worktree setup for missing cache and env

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,6 +1,7 @@
 {
   "setup-worktree": [
-    "cp \"$ROOT_WORKTREE_PATH/apps/coong/.env\" apps/coong/.env",
+    "[ -f \"$ROOT_WORKTREE_PATH/apps/coong/.env\" ] && cp \"$ROOT_WORKTREE_PATH/apps/coong/.env\" apps/coong/.env || true",
+    "[ -d \"$ROOT_WORKTREE_PATH/.turbo\" ] && cp -R \"$ROOT_WORKTREE_PATH/.turbo\" .turbo || true",
     "pnpm install"
   ]
 }


### PR DESCRIPTION
## Summary
- Copy Turborepo `.turbo` cache from the root worktree during Cursor worktree setup
- Skip `.env` and `.turbo` copies when the source is missing so setup does not fail

## Test plan
- [ ] Create a Cursor worktree with root `.env` and `.turbo` present and confirm both are copied
- [ ] Create a Cursor worktree without root `.env` / `.turbo` and confirm setup still completes (`pnpm install` runs)


Made with [Cursor](https://cursor.com)