### PR TITLE
chore: turbo-cache package prepare-build on install

### DIFF
--- a/.github/workflows/__main.yml
+++ b/.github/workflows/__main.yml
@@ -87,7 +87,7 @@ jobs:
           key: ${{ runner.os }}-libraies-${{ hashFiles('packages/**/*.ts') }}
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Build
         run: pnpm run build:@coong/client

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,11 @@ Chat context is volatile. When **why** isn't obvious from code, leave a minimal 
 
 ## Cursor Cloud
 
-pnpm + Turborepo (`@winter-love/web`) · Node ≥22 · pnpm 10.x (`package.json`). `pnpm install` runs workspace `prepare` (package builds; Coong Supabase type gen).
+pnpm + Turborepo (`@winter-love/web`) · Node ≥22 · pnpm 11.x (`package.json`). `pnpm install` runs root `postinstall` → `turbo prepare-build` (package builds; Coong Supabase type gen; Turbo-cached).
 
 - **Coong** — `apps/coong` (SolidStart SSR). `pnpm dev` (:3000). Copy `apps/coong/.env.e2e` → `.env` for dev without Supabase (see `.env.example`).
 - **Storybook** — root. `pnpm storybook:dev` (:6006).
 
-**Commands:** `pnpm lint` · `pnpm test` · `pnpm -r prepare` · `pnpm typecheck` (`apps/coong`)
+**Commands:** `pnpm lint` · `pnpm test` · `turbo prepare-build` · `pnpm typecheck` (`apps/coong`)
 
-**Gotcha:** Without Supabase, auth/DB features error but the app renders. Re-run `pnpm -r prepare` after cleaning `node_modules` or `dist/`.
+**Gotcha:** Without Supabase, auth/DB features error but the app renders. Re-run `turbo prepare-build` after cleaning `node_modules` or `dist/`.

--- a/apps/coong/README.md
+++ b/apps/coong/README.md
@@ -3,7 +3,7 @@
 ## Scripts
 
 - **Setup**
-  - **`pnpm prepare`**: 설치/준비 단계에서 Supabase 타입 생성 실행
+  - **`pnpm prepare-build`**: 설치/준비 단계에서 Supabase 타입 생성 (`turbo prepare-build` / root `postinstall`)
   - **`pnpm supabase:gen-types`**: Supabase 타입 생성
   - **`pnpm typecheck`**: TypeScript 타입 체크만 수행
 - **Dev**

--- a/apps/coong/package.json
+++ b/apps/coong/package.json
@@ -14,7 +14,7 @@
     "dev": "vinxi dev --host",
     "lint": "oxlint src",
     "lint:fix": "oxlint src --fix",
-    "prepare": "pnpm run supabase:gen-types",
+    "prepare-build": "pnpm run supabase:gen-types",
     "prepare:e2e-local-supabase": "jiti scripts/prepare-local-e2e.ts",
     "preview": "node -r dotenv/config ./.output/server/index.mjs",
     "preview:spa": "jiti scripts/preview-proxy.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "test": "vitest run --reporter=dot",
+    "postinstall": "turbo prepare-build",
     "test:storybook": "test-storybook",
     "test:storybook:watch": "test-storybook --watch",
     "test:vitest": "vitest run --reporter=dot",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "vite build",
+    "prepare-build": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/solid-components/package.json
+++ b/packages/solid-components/package.json
@@ -29,7 +29,7 @@
     "build": "vite build && tsc -p tsconfig.solid.json",
     "build:dev": "vite build --minify false && tsc -p tsconfig.solid.json",
     "build:solid": "tsc -p tsconfig.solid.json",
-    "prepare": "pnpm run build",
+    "prepare-build": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "dev": "concurrently \"vite build --watch\" \"tsc -p tsconfig.solid.json --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/solid-test/package.json
+++ b/packages/solid-test/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "vite build",
+    "prepare-build": "pnpm run build",
     "lint": "oxlint src",
     "lint:fix": "oxlint src --fix",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/solid-use/package.json
+++ b/packages/solid-use/package.json
@@ -23,8 +23,8 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "vite build",
     "build:dev": "vite build --minify false",
+    "prepare-build": "pnpm run build:dev",
     "typecheck": "tsc --noEmit",
     "dev": "vite build --watch"
   },

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "vite build",
+    "prepare-build": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "start": "node dist/cli.js build -r 'test/assets' -a '**/*' ./node_modules/sw.js",
     "test": "vitest run"

--- a/packages/tonejs-midi/package.json
+++ b/packages/tonejs-midi/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "pnpm run build:ts && vite build",
     "build:dev": "vite build --minify false",
-    "prepare": "pnpm run build",
+    "prepare-build": "pnpm run build",
     "build:ts": "tsc -p tsconfig.tone.json",
     "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/unocss-config/package.json
+++ b/packages/unocss-config/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "prepare": "vite build"
+    "prepare-build": "pnpm run build"
   },
   "dependencies": {
     "@unocss/core": "catalog:",

--- a/packages/unocss-preset-var/package.json
+++ b/packages/unocss-preset-var/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "unbuild",
-    "prepare": "unbuild"
+    "prepare-build": "pnpm run build"
   },
   "dependencies": {
     "@unocss/core": "catalog:",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -60,8 +60,9 @@
   },
   "scripts": {
     "build": "vite build",
+    "build:dev": "vite build --minify false",
+    "prepare-build": "pnpm run build:dev",
     "typecheck": "tsc --noEmit",
-    "prepare": "vite build",
     "dev": "vite build --watch --minify false"
   },
   "dependencies": {

--- a/packages/vite-plugin-monorepo-alias/package.json
+++ b/packages/vite-plugin-monorepo-alias/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "build": "vite build",
+    "prepare-build": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "dev": "vite build --watch --minify false",
-    "prepare": "vite build",
     "preview": "vite build -c vite.preview.config.mts",
     "publish": "npm publish"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,34 +878,6 @@ importers:
         specifier: 'catalog:'
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
 
-  packages/vite-plugin-cdn:
-    dependencies:
-      '@polka/url':
-        specifier: ^0.5.0
-        version: 0.5.0
-      es-module-lexer:
-        specifier: ^1.7.0
-        version: 1.7.0
-      magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
-      node-fetch:
-        specifier: ^3.3.2
-        version: 3.3.2
-    devDependencies:
-      '@types/node-fetch':
-        specifier: ^2.6.13
-        version: 2.6.13
-      '@winter-love/vite-lib-config':
-        specifier: workspace:*
-        version: link:../vite-lib-config
-      cross-env:
-        specifier: 'catalog:'
-        version: 10.1.0
-      vite:
-        specifier: 'catalog:'
-        version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
-
   packages/vite-plugin-monorepo-alias:
     dependencies:
       vite:
@@ -3552,9 +3524,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@polka/url@0.5.0':
-    resolution: {integrity: sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==}
-
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -4461,9 +4430,6 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@20.11.18':
     resolution: {integrity: sha512-ABT5VWnnYneSBcNWYSCuR05M826RoMyMSGiFivXGx6ZUIsXb9vn4643IEwkg2zbEOSgAiSogtapN2fgc4mAPlw==}
@@ -5605,6 +5571,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -5780,10 +5747,6 @@ packages:
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
-
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -6409,10 +6372,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -6501,10 +6460,6 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -6603,7 +6558,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -6613,7 +6568,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -7709,11 +7664,6 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -7725,10 +7675,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
@@ -9945,10 +9891,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -12449,8 +12391,6 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
-  '@polka/url@0.5.0': {}
-
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -13399,11 +13339,6 @@ snapshots:
   '@types/mime@1.3.5': {}
 
   '@types/minimist@1.2.5': {}
-
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 20.11.18
-      form-data: 4.0.5
 
   '@types/node@20.11.18':
     dependencies:
@@ -15005,8 +14940,6 @@ snapshots:
 
   dargs@7.0.0: {}
 
-  data-uri-to-buffer@4.0.1: {}
-
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -15618,11 +15551,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -15707,10 +15635,6 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
-
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -15747,7 +15671,7 @@ snapshots:
       debug: 4.4.3
       env-paths: 3.0.0
       semver: 7.8.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17149,8 +17073,6 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-domexception@1.0.0: {}
-
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0(encoding@0.1.13):
@@ -17158,12 +17080,6 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-forge@1.4.0: {}
 
@@ -19944,8 +19860,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -13,9 +13,31 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "src/**/*.css"],
-      "outputs": ["dist/**"],
+      "inputs": [
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "src/**/*.css",
+        "package.json",
+        "vite.config.*",
+        "tsconfig.*"
+      ],
+      "outputs": ["dist/**", "es-tone/**"],
       "passThroughEnv": []
+    },
+    "prepare-build": {
+      "dependsOn": ["^prepare-build"],
+      "inputs": [
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "src/**/*.css",
+        "package.json",
+        "vite.config.*",
+        "tsconfig.*",
+        ".env"
+      ],
+      "outputs": ["dist/**", "es-tone/**", ".supabase/**"],
+      "env": ["SUPABASE_PROJECT_ID"],
+      "passThroughEnv": ["SUPABASE_ACCESS_TOKEN"]
     },
     "dev": {
       "cache": false,
@@ -23,11 +45,11 @@
     },
     "typecheck": {
       "dependsOn": ["^typecheck"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts"]
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "package.json", "tsconfig.*"]
     },
     "lint": {
       "dependsOn": ["^lint"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "src/**/*.css"]
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "src/**/*.css", "package.json", "tsconfig.*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace per-package `prepare` with Turbo `prepare-build`, run from root `postinstall` so worktree `.turbo` cache can be reused on `pnpm install`
- Expand Turbo inputs/outputs (configs, `.env`, `es-tone/**`, `.supabase/**`) and Supabase env hashing for safer cache hits
- Align AGENTS/Coong docs; drop `--ignore-scripts` on legacy freeze workflow install

## Test plan
- [ ] `pnpm install` runs `turbo prepare-build` and builds workspace packages
- [ ] Second install (or worktree with copied `.turbo`) shows prepare-build cache hits
- [ ] Coong `.env` / `SUPABASE_PROJECT_ID` change invalidates Coong prepare-build cache
- [ ] `tonejs-midi` cache restore includes usable `dist` + `es-tone` outputs
- [ ] Docs commands (`turbo prepare-build`) match local workflow


Made with [Cursor](https://cursor.com)