### PR TITLE
chore - copy Turbo cache into Codex worktree setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -12,6 +12,10 @@ REPOSITORY_PATH="$(dirname "$(git rev-parse --git-common-dir)")"
 if [ -f "$REPOSITORY_PATH/apps/coong/.env" ]; then
   cp "$REPOSITORY_PATH/apps/coong/.env" apps/coong/.env
 fi
+# Mirror .cursor/worktrees.json: reuse main worktree Turbo cache before install/prepare-build.
+if [ -d "$REPOSITORY_PATH/.turbo" ]; then
+  cp -R "$REPOSITORY_PATH/.turbo" .turbo
+fi
 pnpm install
 git config user.name "kimbichi"
 git config user.email "bichi@live.co.kr"


### PR DESCRIPTION
## Summary
- Copy the main worktree `.turbo` cache into new Codex worktrees before `pnpm install`, matching `.cursor/worktrees.json`
- Speeds up Codex setup when `postinstall` runs `turbo prepare-build`

## Test plan
- [ ] Create a Codex worktree from a machine that already has a populated `.turbo` at the repository root
- [ ] Confirm setup copies `.turbo` into the new worktree before `pnpm install`
- [ ] Confirm setup still succeeds when the source `.turbo` directory is missing


Made with [Cursor](https://cursor.com)