### PR TITLE
docs - extend skill-diet with extract-on-demand and outcome parity

### DIFF
--- a/.agents/skills/skill-diet/SKILL.md
+++ b/.agents/skills/skill-diet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-diet
-description: Reduce an existing Codex skill to its minimum useful form, or decide that the skill should be deleted. Use when the user asks to diet, slim, trim, simplify, minimize, reevaluate, or remove bloat from a skill while preserving its trigger behavior, tone, safety constraints, and practical usefulness.
+description: Reduce an existing Codex skill to its minimum useful form, extract on-demand context into linked sibling files, or decide that the skill should be deleted. Use when the user asks to diet, slim, trim, simplify, minimize, reevaluate, or remove bloat from a skill while preserving its trigger behavior, tone, safety constraints, and practical usefulness.
 ---
 
 # Skill Diet
@@ -11,13 +11,25 @@ Shrink a skill until only durable behavior remains. Prefer deletion when the ski
 
 ## Loop
 
-Repeat until the next deletion would change behavior:
+Repeat until the next deletion or extraction would change behavior:
 
 1. Name the skill's real job in one sentence.
-2. Mark what must survive: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
-3. Delete everything else: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
-4. Re-read the smaller skill as if seeing it for the first time.
-5. Run the smallest validation available. If this skill's script is available, run `node scripts/validate-skill.js <skill_directory>`. For repo changes, also run required format/lint commands.
+2. Mark what must survive in `SKILL.md`: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
+3. Split the rest into delete vs extract:
+   - Delete: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
+   - Extract: useful context the model should not load on every run (long examples, pattern catalogs, deep references, edge-case tables). Move it to a sibling file and leave only a when-to-open link in `SKILL.md`.
+4. Re-read the smaller skill as if seeing it for the first time. Confirm linked files are opened only when the link's condition matches.
+5. Check outcome parity: for the skill's real job (step 1), walk 1–3 typical invocations and confirm the reduced skill still yields the same decisions, constraints, routing, and output contract as before. If parity breaks, restore the missing rule or tighten an extract link — do not ship a smaller skill that changes results.
+6. Run the smallest validation available. If this skill's script is available, run `node scripts/validate-skill.js <skill_directory>`. For repo changes, also run required format/lint commands.
+
+## Extract On Demand
+
+Prefer extraction over inlining when content helps only in some invocations.
+
+- Put extracted files beside the skill (`rules/`, `examples/`, `references/`, or a named `.md`).
+- In `SKILL.md`, keep a one-line conditional link only — e.g. `See ./rules/foo.md when …`. Do not paste or summarize the extracted body.
+- Keep links one level deep from `SKILL.md`. Do not chain reference → reference.
+- Match this repo's pattern: core rules stay in `SKILL.md`; detail lives behind `See ./…` links the agent opens when relevant.
 
 ## Delete Instead
 
@@ -32,7 +44,7 @@ When deleting, remove the whole skill folder and state the reason.
 
 ## Keep
 
-Keep only rules that prevent a likely future mistake. Keep examples only when they define a boundary the model may otherwise miss.
+Keep in `SKILL.md` only rules that prevent a likely future mistake. Keep inline examples only when they define a boundary the model may otherwise miss. Everything else useful but situational goes behind a link.
 
 ## Output
 
@@ -40,5 +52,6 @@ Report:
 
 - decision: kept, reduced, or deleted
 - before/after size
-- what stayed and why
+- what stayed, what was extracted (paths), and why
+- outcome parity: invocations checked and pass/fail
 - validation run

--- a/.agents/skills/skill-diet/SKILL.md
+++ b/.agents/skills/skill-diet/SKILL.md
@@ -7,7 +7,7 @@ description: Reduce an existing Codex skill to its minimum useful form, extract 
 
 ## Goal
 
-Shrink a skill until only durable behavior remains. Prefer deletion when the skill only repeats general model ability, AGENTS.md rules, or non-actionable advice.
+Shrink a skill until only durable behavior remains. Prefer deletion when the skill only repeats general model ability, AGENTS.md rules, or non-actionable advice. Cut and condense aggressively — outcome parity (step 5) is the safety net, so do not keep text "just in case."
 
 ## Loop
 
@@ -15,11 +15,11 @@ Repeat until the next deletion or extraction would change behavior:
 
 1. Name the skill's real job in one sentence.
 2. Mark what must survive in `SKILL.md`: trigger wording, safety constraints, project-specific rules, resource routing, output contract, and one boundary example if needed.
-3. Split the rest into delete vs extract:
+3. Split the rest into delete vs extract. Bias toward bold deletes and tighter wording; restore only if step 5 fails:
    - Delete: history, rationale, duplicated examples, long reference summaries, generic advice, aspirational wording, and examples that do not change decisions.
    - Extract: useful context the model should not load on every run (long examples, pattern catalogs, deep references, edge-case tables). Move it to a sibling file and leave only a when-to-open link in `SKILL.md`.
 4. Re-read the smaller skill as if seeing it for the first time. Confirm linked files are opened only when the link's condition matches.
-5. Check outcome parity: for the skill's real job (step 1), walk 1–3 typical invocations and confirm the reduced skill still yields the same decisions, constraints, routing, and output contract as before. If parity breaks, restore the missing rule or tighten an extract link — do not ship a smaller skill that changes results.
+5. Check outcome parity: for the skill's real job (step 1), walk 1–3 typical invocations and confirm the reduced skill still yields the same decisions, constraints, routing, and output contract as before. If parity breaks, restore the missing rule or tighten an extract link — do not ship a smaller skill that changes results. Prefer mental walkthroughs; if a check creates temporary files or other side effects, revert them before finishing — leave no leftover artifacts from parity checks.
 6. Run the smallest validation available. If this skill's script is available, run `node scripts/validate-skill.js <skill_directory>`. For repo changes, also run required format/lint commands.
 
 ## Extract On Demand


### PR DESCRIPTION
## Summary
- Teach skill-diet to extract situational context into linked sibling files (`rules/`, `examples/`, `references/`) instead of keeping it inline in `SKILL.md`.
- Bias the diet loop toward aggressive deletes/condensation, with outcome parity as the safety net (restore only if parity fails).
- Add an outcome-parity step: walk 1–3 typical invocations; prefer mental walkthroughs; revert any temporary files or side effects before finishing.
- Update the diet report to include extracted paths and parity results.

## Testing
- [ ] Read `.agents/skills/skill-diet/SKILL.md` and confirm Extract On Demand, aggressive-cut bias, parity + cleanup, and loop steps 3–5 are clear.
- [ ] Run `node .agents/skills/skill-diet/scripts/validate-skill.js .agents/skills/skill-diet` (expect: Skill is valid!).
- [ ] Optionally diet a bulky skill and verify extract links, parity reporting, and no leftover parity artifacts.