### PR TITLE
docs - add cleanup-worktrees skill for safe worktree removal

### DIFF
--- a/.agents/skills/cleanup-worktrees/SKILL.md
+++ b/.agents/skills/cleanup-worktrees/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cleanup-worktrees
+description: >-
+  Remove safe git worktrees that have no uncommitted changes and no commits
+  missing from a pull request. Use when the user asks to clean up, prune, or
+  remove worktrees (워크트리 정리, worktree cleanup).
+---
+
+# Cleanup worktrees
+
+Remove linked worktrees that are safe to delete. Worktree only — never delete branches.
+
+## Rules
+
+Remove only when all are true; otherwise skip and say why:
+
+1. Not the current worktree or the primary checkout
+2. Clean: `git -C <path> status --porcelain` empty
+3. HEAD is on a PR (open or merged): some PR `headRefOid` has HEAD as ancestor (`git merge-base --is-ancestor`)
+
+Never use `git worktree remove --force` unless the user asks.
+
+## Workflow
+
+1. `git worktree list --porcelain`
+2. Evaluate each linked worktree except current and primary
+3. From the primary checkout: `git worktree remove <path>` for safe ones, then `git worktree prune`
+4. Report:
+
+```
+Removed:
+- <path> (<branch>) — PR #<n>
+
+Skipped:
+- <path> (<branch>) — <reason>
+```


### PR DESCRIPTION
## Summary
- Add a `cleanup-worktrees` agent skill that removes linked worktrees only when they are clean and every commit is already on an open or merged PR
- Keep current and primary checkouts, and never delete branches or force-remove

## Testing
- [ ] Ask the agent to run worktree cleanup (`워크트리 정리`) and confirm it skips dirty / no-PR worktrees with reasons
- [ ] Confirm a clean worktree whose HEAD is on a PR tip is removed via `git worktree remove` from the primary checkout
- [ ] Confirm the current worktree and primary checkout are never removed