### PR TITLE
docs - add cleanup-branches skill with plan-then-confirm

### DIFF
--- a/.agents/skills/cleanup-branches/SKILL.md
+++ b/.agents/skills/cleanup-branches/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: cleanup-branches
 description: >
-  Delete remote and matching local git branches whose PR is already merged and
-  that have no remaining commits or file changes. Use when the user asks to
-  clean up, prune, or delete merged branches (브랜치 정리, cleanup branches,
-  delete merged branches).
+  Plan and (only after user confirmation) delete remote and matching local git
+  branches whose PR is already merged and that have no remaining commits or
+  file changes. Use when the user asks to clean up, prune, or delete merged
+  branches (브랜치 정리, cleanup branches, delete merged branches).
 ---
 
 # Cleanup branches
 
-원격지에 이미 PR이 합쳐져서 커밋 또는 변경된 파일이 없는 브랜치를 지운다.
-원격과 같은 로컬 브랜치가 있으면 함께 지운다. `main` / `dev` 는 절대 지우지 않는다.
+Delete remote branches whose PR is already merged and that have no leftover
+commits or file changes. Delete matching local branches too. Never delete
+`main` or `dev`.
+
+**Plan first.** Show what would be deleted; delete only after the user
+explicitly asks to delete.
 
 ## Rules
 
@@ -30,15 +34,17 @@ Never force-push or rewrite history. Use `git branch -D` only after the merged-P
 
 1. `git fetch --prune origin`
 2. Candidates: remote heads under `origin` (exclude `main`/`dev`/`HEAD`), plus local-only branches with the same checks
-3. Safe remote → `git push origin --delete <branch>`
-4. Matching safe local → `git branch -D <branch>`
-5. Report:
+3. **Plan (default):** report would-delete vs skipped. Do **not** run `git push --delete` or `git branch -D`.
+4. Stop and wait. Delete only when the user explicitly asks to delete.
+5. **Delete (after confirmation only):** safe remote → `git push origin --delete <branch>`; matching safe local → `git branch -D <branch>`; report removed vs skipped.
 
 ```
-Removed:
+Would delete:
 - origin/<branch> — merged PR #<n>
 - <branch> (local) — matched origin / merged PR #<n>
 
 Skipped:
 - <branch> — <reason>
 ```
+
+After confirmation, use the same shape with `Removed:` instead of `Would delete:`.

--- a/.agents/skills/cleanup-branches/SKILL.md
+++ b/.agents/skills/cleanup-branches/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: cleanup-branches
+description: >
+  Delete remote and matching local git branches whose PR is already merged and
+  that have no remaining commits or file changes. Use when the user asks to
+  clean up, prune, or delete merged branches (브랜치 정리, cleanup branches,
+  delete merged branches).
+---
+
+# Cleanup branches
+
+원격지에 이미 PR이 합쳐져서 커밋 또는 변경된 파일이 없는 브랜치를 지운다.
+원격과 같은 로컬 브랜치가 있으면 함께 지운다. `main` / `dev` 는 절대 지우지 않는다.
+
+## Rules
+
+Delete only when all are true; otherwise skip and say why:
+
+1. Branch is not `main` or `dev` (local or `origin/*`)
+2. Not the currently checked-out branch
+3. A **merged** PR exists for that head (`gh pr list --head <branch> --state merged`)
+4. Tip has no commits beyond a merged PR tip:
+   `git merge-base --is-ancestor <tip> <prHeadRefOid>`
+   (prefer `origin/<branch>` tip; squash/rebase → do **not** require ancestry on `dev`/`main`)
+5. Local delete: if a worktree has the branch checked out, that tree is clean (`status --porcelain` empty); dirty → skip local only
+
+Never force-push or rewrite history. Use `git branch -D` only after the merged-PR checks (plain `-d` often fails after squash).
+
+## Workflow
+
+1. `git fetch --prune origin`
+2. Candidates: remote heads under `origin` (exclude `main`/`dev`/`HEAD`), plus local-only branches with the same checks
+3. Safe remote → `git push origin --delete <branch>`
+4. Matching safe local → `git branch -D <branch>`
+5. Report:
+
+```
+Removed:
+- origin/<branch> — merged PR #<n>
+- <branch> (local) — matched origin / merged PR #<n>
+
+Skipped:
+- <branch> — <reason>
+```


### PR DESCRIPTION
## Summary
- Add `cleanup-branches` agent skill to find remote/local branches whose PR is already merged and that have no leftover commits beyond the merged tip
- Default to a plan-only report (`Would delete` / `Skipped`); delete only after explicit user confirmation
- Protect `main`/`dev`, skip dirty or currently checked-out locals, and handle squash merges via merged-PR tip containment

## Testing
- [ ] Invoke the skill (브랜치 정리) and confirm it only prints a plan, with no deletes
- [ ] After saying to delete, confirm only listed safe remotes/locals are removed
- [ ] Confirm `main` and `dev` are never deleted
- [ ] Confirm branches with open PRs or extra tip commits are skipped with reasons