### PR TITLE
docs - clarify why vitest.workspace pins the root config

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,7 +1,12 @@
 import type {TestProjectConfiguration} from 'vitest/config'
 
 /**
- * Workspace is resolved in the loop
+ * Always use the root `./vitest.config.mts` — do not list per-package projects.
+ *
+ * AI_NOTE - `@winter-love/vite-plugin-monorepo-alias` (`matchWorkspace`) picks
+ * the `/apps/` or `/packages/` segment whose prefix equals the monorepo `root`.
+ * Nested paths like `.../apps/web/.../apps/coong/` need that single root config;
+ * per-package Vitest roots would resolve the wrong workspace and break aliases.
  */
 const workspace: TestProjectConfiguration[] = ['./vitest.config.mts']
 export default workspace


### PR DESCRIPTION
## Summary
- Expand `vitest.workspace.ts` comments to explain why every project must point at the root `vitest.config.mts`
- Document that `monorepo-alias` `matchWorkspace` needs a single monorepo `root` so nested `/apps/` paths do not break aliases

## Test plan
- [ ] Skim `vitest.workspace.ts` comment for accuracy against `matchWorkspace`
- [ ] Confirm `pnpm test` still uses root `vitest.config.mts` as before (comment-only change)


Made with [Cursor](https://cursor.com)