### PR TITLE
docs - include closed PRs in cleanup-worktrees skill

### DIFF
--- a/.agents/skills/cleanup-worktrees/SKILL.md
+++ b/.agents/skills/cleanup-worktrees/SKILL.md
@@ -16,7 +16,7 @@ Remove only when all are true; otherwise skip and say why:
 
 1. Not the current worktree or the primary checkout
 2. Clean: `git -C <path> status --porcelain` empty
-3. HEAD is on a PR (open or merged): some PR `headRefOid` has HEAD as ancestor (`git merge-base --is-ancestor`)
+3. HEAD is on a PR (open, merged, or closed): some PR `headRefOid` has HEAD as ancestor (`git merge-base --is-ancestor`)
 
 Never use `git worktree remove --force` unless the user asks.
 


### PR DESCRIPTION
## Summary
- Treat closed (unmerged) PRs the same as open/merged when deciding a worktree is safe to remove
- Keeps the existing ancestor check against PR `headRefOid`

## Testing
- [ ] Read `.agents/skills/cleanup-worktrees/SKILL.md` and confirm rule 3 lists open, merged, or closed
- [ ] Optionally run the skill against a clean worktree whose HEAD is on a closed PR and confirm it is eligible for removal