### PR TITLE
docs - include closed PRs in cleanup-branches skill

### DIFF
--- a/.agents/skills/cleanup-branches/SKILL.md
+++ b/.agents/skills/cleanup-branches/SKILL.md
@@ -2,16 +2,17 @@
 name: cleanup-branches
 description: >
   Plan and (only after user confirmation) delete remote and matching local git
-  branches whose PR is already merged and that have no remaining commits or
-  file changes. Use when the user asks to clean up, prune, or delete merged
-  branches (브랜치 정리, cleanup branches, delete merged branches).
+  branches whose PR is already merged or closed (not merged) and that have no
+  remaining commits or file changes. Use when the user asks to clean up, prune,
+  or delete merged/closed branches (브랜치 정리, cleanup branches, delete merged
+  branches).
 ---
 
 # Cleanup branches
 
-Delete remote branches whose PR is already merged and that have no leftover
-commits or file changes. Delete matching local branches too. Never delete
-`main` or `dev`.
+Delete remote branches whose PR is already **merged** or **closed (not merged)**
+and that have no leftover commits or file changes. Delete matching local
+branches too. Never delete `main` or `dev`.
 
 **Plan first.** Show what would be deleted; delete only after the user
 explicitly asks to delete.
@@ -22,25 +23,36 @@ Delete only when all are true; otherwise skip and say why:
 
 1. Branch is not `main` or `dev` (local or `origin/*`)
 2. Not the currently checked-out branch
-3. A **merged** PR exists for that head (`gh pr list --head <branch> --state merged`)
-4. Tip has no commits beyond a merged PR tip:
+3. No **open** PR for that head (`gh pr list --head <branch> --state open`)
+4. A **merged** or **closed** PR exists for that head:
+   - prefer merged: `gh pr list --head <branch> --state merged`
+   - else closed (not merged): `gh pr list --head <branch> --state closed`
+5. Tip has no commits beyond that PR tip:
    `git merge-base --is-ancestor <tip> <prHeadRefOid>`
-   (prefer `origin/<branch>` tip; squash/rebase → do **not** require ancestry on `dev`/`main`)
-5. Local delete: if a worktree has the branch checked out, that tree is clean (`status --porcelain` empty); dirty → skip local only
+   (prefer `origin/<branch>` tip; squash/rebase → do **not** require ancestry on
+   `dev`/`main`)
+6. Local delete: if a worktree has the branch checked out, that tree is clean
+   (`status --porcelain` empty); dirty → skip local only
 
-Never force-push or rewrite history. Use `git branch -D` only after the merged-PR checks (plain `-d` often fails after squash).
+Never force-push or rewrite history. Use `git branch -D` only after the PR
+checks (plain `-d` often fails after squash).
 
 ## Workflow
 
 1. `git fetch --prune origin`
-2. Candidates: remote heads under `origin` (exclude `main`/`dev`/`HEAD`), plus local-only branches with the same checks
-3. **Plan (default):** report would-delete vs skipped. Do **not** run `git push --delete` or `git branch -D`.
+2. Candidates: remote heads under `origin` (exclude `main`/`dev`/`HEAD`), plus
+   local-only branches with the same checks
+3. **Plan (default):** report would-delete vs skipped. Do **not** run
+   `git push --delete` or `git branch -D`.
 4. Stop and wait. Delete only when the user explicitly asks to delete.
-5. **Delete (after confirmation only):** safe remote → `git push origin --delete <branch>`; matching safe local → `git branch -D <branch>`; report removed vs skipped.
+5. **Delete (after confirmation only):** safe remote →
+   `git push origin --delete <branch>`; matching safe local →
+   `git branch -D <branch>`; report removed vs skipped.
 
 ```
 Would delete:
 - origin/<branch> — merged PR #<n>
+- origin/<branch> — closed PR #<n> (not merged)
 - <branch> (local) — matched origin / merged PR #<n>
 
 Skipped:


### PR DESCRIPTION
## Summary
- Expand `cleanup-branches` so remote/local branches with a closed (not merged) PR are cleanup candidates, not only merged ones.
- Skip branches that still have an open PR; prefer merged over closed when both exist.
- Keep the tip-ancestry and plan-then-confirm safety rules; label closed deletions in the plan output.

## Testing
- [ ] Read `.agents/skills/cleanup-branches/SKILL.md` and confirm open → skip, merged → delete, closed → delete when tip has no extra commits.
- [ ] Optionally run the skill in plan-only mode and verify closed PR branches appear under `Would delete:` with `(not merged)`.