### PR TITLE
docs - annotate vitest.setup purpose and cleanup

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,13 @@
+/**
+ * Vitest setupFiles 엔트리.
+ * 각 테스트 파일 실행 전에 한 번 로드되며, jest-dom matcher 확장과
+ * Solid Testing Library DOM cleanup을 전역으로 적용한다.
+ */
 import '@testing-library/jest-dom/vitest'
 import {cleanup} from '@solidjs/testing-library'
 import {afterEach} from 'vitest'
 
+// render()로 남은 컴포넌트·DOM이 다음 테스트로 새지 않게 한다.
 afterEach(() => {
   cleanup()
 })


### PR DESCRIPTION
## Summary
- `vitest.setup.ts`에 setupFiles 역할과 jest-dom / Solid Testing Library cleanup 적용 범위를 설명하는 파일 주석을 추가한다.
- `afterEach`의 `cleanup()`이 render 잔여물 격리를 위한 것임을 한 줄로 남긴다.

## Testing
- [ ] 주석만 변경인지 diff로 확인
- [ ] `pnpm test`가 기존과 같이 동작하는지 스모크 확인(선택)