### PR TITLE
docs - annotate vitest.config keys for readability

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,12 +4,16 @@ import {defineConfig} from 'vitest/config'
 import solid from 'vite-plugin-solid'
 
 export default defineConfig({
+  // Vite 빌드 옵션 (테스트 시 모듈/번들 대상에 영향)
   build: {
+    // 트랜스파일 타깃 ECMAScript 버전
     target: 'esnext',
   },
+  // Vite/Vitest 플러그인 목록
   plugins: [
     solid() as any,
     monorepoAlias({
+      // 패키지별 import 경로 별칭 (`@` → `src` 등)
       alias: {
         DEFAULT: {
           '@': 'src',
@@ -20,22 +24,30 @@ export default defineConfig({
         },
       },
 
+      // 모노레포 루트 절대 경로
       root: fileURLToPath(new URL('./', import.meta.url)),
+      // OS별 경로 구분자
       separator: process.platform === 'win32' ? '\\' : '/',
+      // workspace 패키지로 인식할 경로 패턴
       workspacePaths: [/\/apps\//u, /\/packages\//u],
     }),
   ],
+  // 모듈 resolve 옵션
   resolve: {
-    // for solidjs testing
+    // Solid.js 테스트용 export condition (development + browser)
     conditions: ['development', 'browser'],
   },
+  // Vitest 테스트 실행 옵션
   test: {
+    // 테스트 런타임 환경 (DOM API 제공)
     environment: 'jsdom',
+    // 테스트로 포함할 파일 glob 패턴
     include: [
       'packages/*/src/**/*.spec.?(c|m)[jt]s?(x)',
       'apps/*/src/**/*.spec.?(c|m)[jt]s?(x)',
       '.agents/skills/*/scripts/**/*.spec.ts',
     ],
+    // 각 테스트 파일 실행 전 로드할 셋업 파일
     setupFiles: ['./vitest.setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- `vitest.config.mts`의 각 설정 키 위에 역할 설명 주석을 추가했습니다.
- Solid 테스트용 `resolve.conditions` 기존 주석도 더 구체적으로 다듬었습니다.

## Testing
- [ ] `vitest.config.mts` 주석이 각 키 의미와 맞는지 확인
- [ ] 설정 값 변경 없음 → 기존 테스트 실행에 영향 없는지 확인 (`pnpm test`는 선택)