### PR TITLE
Remove es-toolkit compatibility imports

### DIFF
--- a/packages/solid-use/src/debounce/index.spec.ts
+++ b/packages/solid-use/src/debounce/index.spec.ts
@@ -1,10 +1,18 @@
 import {useDebounce} from './'
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {renderHook} from '@solidjs/testing-library'
 
 describe('useDebounce', () => {
-  it('should debounce calling the callback function', () => {
+  beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should debounce calling the callback function', () => {
     const options = {leading: true}
     const args = ['hello']
     const callback = vi.fn()
@@ -24,11 +32,9 @@ describe('useDebounce', () => {
     vi.advanceTimersByTime(100)
     expect(callback).toHaveBeenCalledTimes(2)
     cleanup()
-    vi.useRealTimers()
   })
 
   it('should cancel debounce with dispose', () => {
-    vi.useFakeTimers()
     const options = {leading: true}
     const args = ['hello']
     const callback = vi.fn()
@@ -41,11 +47,9 @@ describe('useDebounce', () => {
     cleanup()
     vi.advanceTimersByTime(50)
     expect(callback).toHaveBeenCalledTimes(1)
-    vi.useRealTimers()
   })
 
   it('should cancel debounce', () => {
-    vi.useFakeTimers()
     const options = {leading: true}
     const args = ['hello']
     const callback = vi.fn()
@@ -59,7 +63,6 @@ describe('useDebounce', () => {
     vi.advanceTimersByTime(50)
     expect(callback).toHaveBeenCalledTimes(1)
     cleanup()
-    vi.useRealTimers()
   })
 
   it('should flush debounce', () => {
@@ -77,6 +80,54 @@ describe('useDebounce', () => {
     expect(callback).toHaveBeenCalledTimes(2)
     vi.advanceTimersByTime(100)
     expect(callback).toHaveBeenCalledTimes(2)
+    cleanup()
+  })
+
+  it('should execute on the trailing edge by default', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() => useDebounce(callback, 100))
+
+    result.execute('trailing')
+
+    expect(callback).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('trailing')
+    cleanup()
+  })
+
+  it('should not execute twice for one call with both edges enabled', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() =>
+      useDebounce(callback, 100, {leading: true, trailing: true}),
+    )
+
+    result.execute('leading')
+
+    expect(callback).toHaveBeenCalledOnce()
+
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledOnce()
+    cleanup()
+  })
+
+  it('should execute when maxWait is reached during repeated calls', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() => useDebounce(callback, 100, {maxWait: 150}))
+
+    result.execute('first')
+    vi.advanceTimersByTime(50)
+    result.execute('second')
+    vi.advanceTimersByTime(50)
+    result.execute('third')
+    vi.advanceTimersByTime(50)
+    result.execute('fourth')
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('fourth')
     cleanup()
   })
 })

--- a/packages/solid-use/src/debounce/index.ts
+++ b/packages/solid-use/src/debounce/index.ts
@@ -1,10 +1,9 @@
-import {debounce} from 'es-toolkit/compat'
 import {MaybeAccessor} from 'src/types'
 import {resolveAccessor} from 'src/resolve-accessor'
+import {debounce, type DebouncedFunc, type DebounceSettings} from 'src/internal/debounce'
 import {createEffect, onCleanup} from 'solid-js'
 
-export type DebounceSettings = NonNullable<Parameters<typeof debounce>[2]>
-export type DebouncedFunc<T extends (...args: any) => any> = ReturnType<typeof debounce<T>>
+export type {DebouncedFunc, DebounceSettings}
 
 export const createDebounce = <T extends (...args: any) => any>(
   callback: T,

--- a/packages/solid-use/src/internal/debounce.ts
+++ b/packages/solid-use/src/internal/debounce.ts
@@ -1,0 +1,69 @@
+import {debounce as baseDebounce} from 'es-toolkit/function'
+
+export interface DebounceSettings {
+  leading?: boolean
+  maxWait?: number
+  trailing?: boolean
+}
+
+export interface DebouncedFunc<T extends (...args: any[]) => any> {
+  (...args: Parameters<T>): ReturnType<T> | undefined
+  cancel(): void
+  flush(): ReturnType<T> | undefined
+}
+
+// AI_NOTE - Preserve the published leading/trailing/maxWait contract while using the modern API.
+export const debounce = <T extends (...args: any[]) => any>(
+  func: T,
+  debounceMs: number = 0,
+  options: DebounceSettings = {},
+): DebouncedFunc<T> => {
+  const {leading = false, maxWait, trailing = true} = options
+  const edges: Array<'leading' | 'trailing'> = []
+
+  if (leading) {
+    edges.push('leading')
+  }
+
+  if (trailing) {
+    edges.push('trailing')
+  }
+
+  let result: ReturnType<T> | undefined
+  let pendingAt: null | number = null
+  const debounced = baseDebounce(
+    (...args: Parameters<T>) => {
+      result = func(...args)
+      pendingAt = null
+    },
+    debounceMs,
+    {edges},
+  )
+
+  const wrapped = (...args: Parameters<T>): ReturnType<T> | undefined => {
+    if (maxWait !== undefined) {
+      pendingAt ??= Date.now()
+
+      if (Date.now() - pendingAt >= maxWait) {
+        result = func(...args)
+        pendingAt = Date.now()
+        debounced.cancel()
+        debounced.schedule()
+
+        return result
+      }
+    }
+
+    debounced(...args)
+
+    return result
+  }
+
+  const flush = (): ReturnType<T> | undefined => {
+    debounced.flush()
+
+    return result
+  }
+
+  return Object.assign(wrapped, {cancel: debounced.cancel, flush})
+}

--- a/packages/solid-use/src/internal/throttle.ts
+++ b/packages/solid-use/src/internal/throttle.ts
@@ -1,0 +1,22 @@
+import {debounce, type DebouncedFunc} from './debounce'
+
+export interface ThrottleSettings {
+  leading?: boolean
+  trailing?: boolean
+}
+
+export type ThrottledFunc<T extends (...args: any[]) => any> = DebouncedFunc<T>
+
+export const throttle = <T extends (...args: any[]) => any>(
+  func: T,
+  throttleMs: number = 0,
+  options: ThrottleSettings = {},
+): ThrottledFunc<T> => {
+  const {leading = true, trailing = true} = options
+
+  return debounce(func, throttleMs, {
+    leading,
+    maxWait: throttleMs,
+    trailing,
+  })
+}

--- a/packages/solid-use/src/throttle/index.spec.ts
+++ b/packages/solid-use/src/throttle/index.spec.ts
@@ -5,17 +5,18 @@ import {renderHook} from '@solidjs/testing-library'
 describe('useThrottle', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(0)
   })
 
   afterEach(() => {
-    vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('should throttle calling the callback function', () => {
     const options = {leading: true}
     const args = ['hello']
     const callback = vi.fn()
-    const {result: throttle} = renderHook(() => useThrottle(callback, 100, options))
+    const {result: throttle, cleanup} = renderHook(() => useThrottle(callback, 100, options))
 
     throttle.execute(...args)
     expect(callback).toHaveBeenCalledTimes(1)
@@ -27,5 +28,72 @@ describe('useThrottle', () => {
     expect(callback).toHaveBeenCalledTimes(1)
     vi.advanceTimersByTime(50)
     expect(callback).toHaveBeenCalledTimes(2)
+    cleanup()
+  })
+
+  it('should delay the first call when the leading edge is disabled', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() =>
+      useThrottle(callback, 100, {leading: false, trailing: true}),
+    )
+
+    result.execute('trailing')
+
+    expect(callback).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('trailing')
+    cleanup()
+  })
+
+  it('should not execute a trailing call when the trailing edge is disabled', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() =>
+      useThrottle(callback, 100, {leading: true, trailing: false}),
+    )
+
+    result.execute('leading')
+    result.execute('ignored')
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('leading')
+
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledOnce()
+    cleanup()
+  })
+
+  it('should cancel a pending trailing call', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() => useThrottle(callback, 100))
+
+    result.execute('leading')
+    result.execute('trailing')
+    result.cancel()
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('leading')
+    cleanup()
+  })
+
+  it('should flush a pending trailing call', () => {
+    const callback = vi.fn()
+    const {result, cleanup} = renderHook(() => useThrottle(callback, 100))
+
+    result.execute('leading')
+    result.execute('trailing')
+    result.flush()
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith('trailing')
+
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    cleanup()
   })
 })

--- a/packages/solid-use/src/throttle/index.ts
+++ b/packages/solid-use/src/throttle/index.ts
@@ -1,10 +1,9 @@
-import {throttle} from 'es-toolkit/compat'
 import {MaybeAccessor} from 'src/types'
 import {resolveAccessor} from 'src/resolve-accessor'
+import {throttle, type ThrottledFunc, type ThrottleSettings} from 'src/internal/throttle'
 import {createEffect, onCleanup} from 'solid-js'
 
-export type ThrottleSettings = NonNullable<Parameters<typeof throttle>[2]>
-export type ThrottledFunc<T extends (...args: any) => any> = ReturnType<typeof throttle<T>>
+export type {ThrottledFunc, ThrottleSettings}
 
 export const createThrottle = <T extends (...args: any) => any>(
   callback: T,

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -15,3 +15,7 @@ TypeScript utilities grouped by responsibility and runtime.
 ## Public API
 
 All distributable modules are intentionally available through subpath exports. The module structure is part of the public surface.
+
+## es-toolkit imports
+
+Do not import from `es-toolkit/compat`. Use modern category subpaths such as `es-toolkit/array`, `es-toolkit/function`, `es-toolkit/predicate`, and `es-toolkit/string`. If no modern API exists, use a native platform API or a local implementation that preserves the package contract.

--- a/packages/utils/src/browser/dom/get-element/index.ts
+++ b/packages/utils/src/browser/dom/get-element/index.ts
@@ -1,4 +1,4 @@
-import {isNil} from 'es-toolkit/compat'
+import {isNil} from 'es-toolkit/predicate'
 
 export const getElement = (value?: Element | string | null): null | Element | undefined => {
   if (isNil(value)) {

--- a/packages/utils/src/browser/dom/is-element/index.ts
+++ b/packages/utils/src/browser/dom/is-element/index.ts
@@ -1,5 +1,5 @@
 import {getWindow} from 'src/browser/dom/get-window'
-import {isUndefined} from 'src/core/predicates/is-undefined'
+import {isUndefined} from 'es-toolkit/predicate'
 
 export const isElement = (value: any): value is Element => {
   const window = getWindow()

--- a/packages/utils/src/browser/dom/is-window/index.ts
+++ b/packages/utils/src/browser/dom/is-window/index.ts
@@ -1,5 +1,5 @@
 import {getWindow} from 'src/browser/dom/get-window'
-import {isUndefined} from 'src/core/predicates/is-undefined'
+import {isUndefined} from 'es-toolkit/predicate'
 
 export const isWindow = (value: any): value is Window => {
   const window = getWindow()

--- a/packages/utils/src/core/collections/to-array/index.ts
+++ b/packages/utils/src/core/collections/to-array/index.ts
@@ -1,5 +1,5 @@
 import {MaybeArray} from 'src/core/types/shared'
-import {isNil} from 'es-toolkit/compat'
+import {isNil} from 'es-toolkit/predicate'
 
 /**
  * return an array always

--- a/packages/utils/src/core/functions/default-value/index.ts
+++ b/packages/utils/src/core/functions/default-value/index.ts
@@ -1,4 +1,4 @@
-import {isUndefined} from 'src/core/predicates/is-undefined'
+import {isUndefined} from 'es-toolkit/predicate'
 import {toValue} from 'src/core/functions/to-value'
 import {MaybeFunction} from 'src/core/types/shared'
 

--- a/packages/utils/src/core/predicates/is-not-null/index.ts
+++ b/packages/utils/src/core/predicates/is-not-null/index.ts
@@ -1,3 +1,4 @@
+import {isNull} from 'es-toolkit/predicate'
 import {NotNull} from 'src/core/types/shared'
 
 /**
@@ -5,4 +6,4 @@ import {NotNull} from 'src/core/types/shared'
  * @param value - The value to check
  * @returns True if the value is not null, false otherwise
  */
-export const isNotNull = <T>(value: T): value is NotNull<T> => value !== null
+export const isNotNull = <T>(value: T): value is NotNull<T> => !isNull(value)

--- a/packages/utils/src/core/predicates/is-not-undefined/index.ts
+++ b/packages/utils/src/core/predicates/is-not-undefined/index.ts
@@ -1,3 +1,4 @@
+import {isUndefined} from 'es-toolkit/predicate'
 import {NotUndefined} from 'src/core/types/shared'
 
 /**
@@ -13,4 +14,4 @@ import {NotUndefined} from 'src/core/types/shared'
  * }
  * ```
  */
-export const isNotUndefined = <T>(value: T): value is NotUndefined<T> => value !== undefined
+export const isNotUndefined = <T>(value: T): value is NotUndefined<T> => !isUndefined(value)

--- a/packages/utils/src/core/predicates/is-promise/index.ts
+++ b/packages/utils/src/core/predicates/is-promise/index.ts
@@ -1,4 +1,4 @@
-import {isNil} from 'es-toolkit/compat'
+import {isNil} from 'es-toolkit/predicate'
 
 export type ToBePromiseType<T> = T extends {
   catch: (...arg: any) => any
@@ -8,6 +8,11 @@ export type ToBePromiseType<T> = T extends {
   ? Promise<U>
   : never
 
+/**
+ * Promise-like 객체인지 확인합니다.
+ *
+ * `then`, `catch`, `finally` 메서드를 모두 가진 객체를 검사합니다.
+ */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export const isPromise = <T>(value: T): value is ToBePromiseType<T> => {

--- a/packages/utils/src/core/predicates/is-undefined/index.ts
+++ b/packages/utils/src/core/predicates/is-undefined/index.ts
@@ -1,1 +1,6 @@
+/**
+ * @deprecated 이 유틸은 삭제 예정입니다. `es-toolkit/predicate`의 `isUndefined`를 사용하세요.
+ *
+ * import {isUndefined} from 'es-toolkit/predicate'
+ */
 export const isUndefined = (value: any): value is undefined => value === undefined

--- a/packages/utils/src/data/path/join-path/index.ts
+++ b/packages/utils/src/data/path/join-path/index.ts
@@ -1,4 +1,4 @@
-import {flatten} from 'es-toolkit/compat'
+import {flatten} from 'es-toolkit/array'
 
 export const joinPath = (...paths: string[]) => {
   return flatten(paths.map((path) => path.split('/').filter(Boolean))).join('/')

--- a/packages/utils/src/data/path/url/to-query-record.ts
+++ b/packages/utils/src/data/path/url/to-query-record.ts
@@ -1,5 +1,5 @@
 // todo support array & object
-import {trim} from 'es-toolkit/compat'
+import {trim} from 'es-toolkit/string'
 
 // URLSearchParams 를 쓴느 것이 더 좋을까 ?
 export interface ToQueryRecodeOptions {

--- a/packages/utils/src/data/path/url/to-query-string.ts
+++ b/packages/utils/src/data/path/url/to-query-string.ts
@@ -1,4 +1,4 @@
-import {trim} from 'es-toolkit/compat'
+import {trim} from 'es-toolkit/string'
 import {joinStringQueries} from './join-string-queries'
 
 export interface ToQueryStringOptions {

--- a/packages/utils/src/formatting/number/to-korean-number/index.ts
+++ b/packages/utils/src/formatting/number/to-korean-number/index.ts
@@ -1,11 +1,7 @@
-import {chunk, compact, flow, join, last, map, reverse} from 'es-toolkit/compat'
-import {flipArgsFactory} from 'src/core/functions/be-factory'
+import {chunk, compact, last} from 'es-toolkit/array'
 import {freeze} from 'src/core/functions/freeze'
 import {toNumber} from 'src/formatting/number/to-number'
 
-const chunkFp = flipArgsFactory(chunk)
-const mapFp = flipArgsFactory(map)
-const joinFp = flipArgsFactory(join)
 const _numberNames = freeze(['0', '일', '이', '삼', '사', '오', '육', '칠', '팔', '구'])
 
 const _numberUnitNames = freeze(['', '만', '억', '조', '경', '해', '자', '양', '구', '간', '정'])
@@ -79,22 +75,26 @@ export const toKoreanNumberFn = ({
   joinString = '',
   firstOne = false,
   joinGroup = '',
-}: NumberToKoreanOptions = {}) =>
-  flow(
-    anyToStringArray,
-    mode === 'all' ? mapFp((value) => _numberNames[Number(value)]) : (value) => value,
-    reverse,
-    chunkFp(KoreanChunk),
-    mode === 'number'
-      ? mapFp(removeUselessZero)
-      : mapFp((value: string[], index: number, array: string[][]) =>
-          addSmallNumberUnit(value, !firstOne || index < array.length - 1),
-        ),
-    mapFp((value: string[], index: number) => addNumberUnit(value, index)),
-    mapFp((value: string[]) => compact(value).reverse().join(joinString)),
-    reverse,
-    joinFp(joinGroup),
-  )
+}: NumberToKoreanOptions = {}) => {
+  return (value: unknown) => {
+    const numberStrings = anyToStringArray(value)
+    const numberNames =
+      mode === 'all' ? numberStrings.map((item) => _numberNames[Number(item)]) : numberStrings
+    const numberGroups = chunk(numberNames.reverse(), KoreanChunk)
+    const smallUnitGroups =
+      mode === 'number'
+        ? numberGroups.map(removeUselessZero)
+        : numberGroups.map((group, index, groups) =>
+            addSmallNumberUnit(group, !firstOne || index < groups.length - 1),
+          )
+
+    return smallUnitGroups
+      .map(addNumberUnit)
+      .map((group) => compact(group).reverse().join(joinString))
+      .reverse()
+      .join(joinGroup)
+  }
+}
 
 export const toKoreanNumber = (value?: unknown, options?: NumberToKoreanOptions) =>
   toKoreanNumberFn(options)(value)

--- a/packages/utils/src/formatting/number/to-number/__tests__/index.spec.ts
+++ b/packages/utils/src/formatting/number/to-number/__tests__/index.spec.ts
@@ -31,6 +31,12 @@ describe('to-number', () => {
 
     expect(result).toBe(20)
   })
+
+  it('should return the fallback with a symbol', () => {
+    const result = toNumber(Symbol('value'), 20)
+
+    expect(result).toBe(20)
+  })
 })
 
 describe('to-number-or-undefined', () => {
@@ -54,6 +60,16 @@ describe('to-number-or-undefined', () => {
 
   it('should return undefined if value is an object', () => {
     const result = toNumberOrUndefined({name: 'foo'})
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined if number conversion throws', () => {
+    const result = toNumberOrUndefined({
+      valueOf: () => {
+        throw new Error('conversion failed')
+      },
+    })
 
     expect(result).toBeUndefined()
   })

--- a/packages/utils/src/formatting/number/to-number/index.ts
+++ b/packages/utils/src/formatting/number/to-number/index.ts
@@ -1,9 +1,15 @@
-import {toNumber as _toNumber} from 'es-toolkit/compat'
-
 export const toNumberOrUndefined = (value?: unknown): number | undefined => {
-  const number = _toNumber(value)
+  if (typeof value === 'symbol') {
+    return undefined
+  }
 
-  return Number.isNaN(number) ? undefined : number
+  try {
+    const number = Number(value)
+
+    return Number.isNaN(number) ? undefined : number
+  } catch {
+    return undefined
+  }
 }
 
 export const toNumber = (value?: unknown, failValue: number = 0): number => {

--- a/packages/vite-lib-config/index.mjs
+++ b/packages/vite-lib-config/index.mjs
@@ -1,4 +1,4 @@
-import {camelCase} from 'es-toolkit/compat'
+import {camelCase} from 'es-toolkit/string'
 import {readFileSync} from 'node:fs'
 import path from 'node:path'
 import {defineConfig} from 'vite'
@@ -54,7 +54,7 @@ export const createConfig = ({
             ...newEntry,
           },
           formats: ['es', 'cjs'],
-          name: camelCase(name),
+          name: camelCase(name ?? ''),
         },
         rollupOptions: {
           external: (id) =>


### PR DESCRIPTION
## Summary

- Replace es-toolkit compatibility imports with modern category entrypoints and native APIs
- Preserve debounce and throttle leading, trailing, maxWait, cancel, and flush behavior through local adapters
- Add regression tests and document the compatibility import ban for utils

## Testing

- pnpm exec vitest run packages/solid-use/src/debounce/index.spec.ts packages/solid-use/src/throttle/index.spec.ts packages/utils/src/formatting/number/to-number/__tests__/index.spec.ts
- pnpm --filter @winter-love/solid-use typecheck
- pnpm --filter @winter-love/utils typecheck
- pnpm --filter @winter-love/solid-use build
- pnpm --filter @winter-love/utils build
- pnpm lint (0 errors; 26 pre-existing warnings)
- pnpm test (872 passed, 2 skipped; unrelated use-select-menu DOMRect test remains failing)