### PR TITLE
update - refresh worktree base onto latest origin/dev

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -7,8 +7,22 @@ script = "cd "
 
 [setup.darwin]
 script = '''
+# AI_NOTE - Refresh base `dev` before entering the new worktree so setup starts from latest origin/dev (AGENTS.md).
+SOURCE_TREE_PATH="${CODEX_SOURCE_TREE_PATH:-}"
+if [ -n "$SOURCE_TREE_PATH" ]; then
+  git -C "$SOURCE_TREE_PATH" fetch origin
+  # Fast-forward local `dev` only; ignore when diverged or unavailable.
+  git -C "$SOURCE_TREE_PATH" fetch origin dev:dev || true
+fi
+
 cd "$CODEX_WORKTREE_PATH"
-REPOSITORY_PATH="$(dirname "$(git rev-parse --git-common-dir)")"
+REPOSITORY_PATH="${CODEX_SOURCE_TREE_PATH:-$(dirname "$(git rev-parse --git-common-dir)")}"
+
+# New worktree with no local commits/changes: align onto latest origin/dev.
+if [ -z "$(git status --porcelain)" ] && [ "$(git rev-list --count origin/dev..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
+  git reset --hard origin/dev
+fi
+
 if [ -f "$REPOSITORY_PATH/apps/coong/.env" ]; then
   cp "$REPOSITORY_PATH/apps/coong/.env" apps/coong/.env
 fi

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,8 @@
 {
   "setup-worktree": [
+    "git -C \"$ROOT_WORKTREE_PATH\" fetch origin",
+    "git -C \"$ROOT_WORKTREE_PATH\" fetch origin dev:dev || true",
+    "if [ -z \"$(git status --porcelain)\" ] && [ \"$(git rev-list --count origin/dev..HEAD 2>/dev/null || echo 1)\" -eq 0 ]; then git reset --hard origin/dev; fi",
     "[ -f \"$ROOT_WORKTREE_PATH/apps/coong/.env\" ] && cp \"$ROOT_WORKTREE_PATH/apps/coong/.env\" apps/coong/.env || true",
     "[ -d \"$ROOT_WORKTREE_PATH/.turbo\" ] && cp -R \"$ROOT_WORKTREE_PATH/.turbo\" .turbo || true",
     "pnpm install"


### PR DESCRIPTION
## Summary
- Codex worktree setup now fetches and fast-forwards the source-tree `dev` branch before entering the new worktree
- Clean new worktrees with no local commits are aligned onto `origin/dev` so installs start from the latest base
- The same refresh steps are mirrored in Cursor `.cursor/worktrees.json`

## Test plan
- [ ] Create a new Codex worktree and confirm setup fetches `origin` / updates local `dev` before `pnpm install`
- [ ] Confirm a clean new worktree lands on the latest `origin/dev` tip
- [ ] Confirm a worktree with local commits is not hard-reset
- [ ] Create a Cursor worktree and confirm the mirrored setup commands run without error


Made with [Cursor](https://cursor.com)