### PR TITLE
Remove beFactory and add PR type checking

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,38 @@
+name: Typecheck
+
+on:
+  pull_request:
+    branches: [dev, master]
+
+concurrency:
+  group: typecheck-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.8.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/packages/utils/src/core/functions/be-factory/__tests__/index.spec.ts
+++ b/packages/utils/src/core/functions/be-factory/__tests__/index.spec.ts
@@ -1,10 +1,10 @@
 import {chunk} from 'es-toolkit/array'
-import {describe, expect, it} from 'vitest'
-import {beFactory} from '../'
+import {describe, expect, expectTypeOf, it} from 'vitest'
+import {flipArgsFactory} from '../'
 
-describe('be-factory', () => {
-  it('should be a function', () => {
-    const chunkFp = beFactory(chunk)
+describe('flipArgsFactory', () => {
+  it('should apply the first parameter after the remaining parameters', () => {
+    const chunkFp = flipArgsFactory(chunk)
     const runChunk = chunkFp(2)
 
     expect(runChunk([1, 2, 3, 4, 5, 6, 7, 8])).toEqual([
@@ -13,5 +13,19 @@ describe('be-factory', () => {
       [5, 6],
       [7, 8],
     ])
+  })
+
+  it('should preserve parameter and return types', () => {
+    const formatValue = (value: number, prefix: string, suffix?: string) => {
+      return `${prefix}${value}${suffix ?? ''}`
+    }
+
+    const withAffixes = flipArgsFactory(formatValue)
+    const runFormat = withAffixes('$', '!')
+
+    expectTypeOf(withAffixes).parameters.toEqualTypeOf<[prefix: string, suffix?: string]>()
+    expectTypeOf(runFormat).parameters.toEqualTypeOf<[value: number]>()
+    expectTypeOf(runFormat).returns.toEqualTypeOf<string>()
+    expect(runFormat(42)).toBe('$42!')
   })
 })

--- a/packages/utils/src/core/functions/be-factory/index.ts
+++ b/packages/utils/src/core/functions/be-factory/index.ts
@@ -1,14 +1,9 @@
-import {Drop, Shift} from 'src/core/types/shared'
-
-export const flipArgsFactory = <T extends (...args: any) => any>(func: T) => {
-  return (...args: Drop<Parameters<T>>) => {
-    return (value: Shift<Parameters<T>>) => {
+export const flipArgsFactory = <First, Rest extends unknown[], Result>(
+  func: (value: First, ...args: Rest) => Result,
+) => {
+  return (...args: Rest) => {
+    return (value: First): Result => {
       return func(value, ...args)
     }
   }
 }
-
-/**
- * @deprecated Use `flipArgsFactory` instead
- */
-export const beFactory = flipArgsFactory


### PR DESCRIPTION
## Summary

- Remove the deprecated beFactory alias
- Preserve flipArgsFactory parameter and return types
- Run the repository typecheck for pull requests targeting dev or master

## Testing

- pnpm exec vitest run packages/utils/src/core/functions/be-factory/__tests__/index.spec.ts
- pnpm typecheck
- pnpm lint
- pnpm format