### PR TITLE
Validate CSS number formatting inputs

### DIFF
--- a/packages/utils/src/formatting/css/add-unit/__tests__/index.spec.ts
+++ b/packages/utils/src/formatting/css/add-unit/__tests__/index.spec.ts
@@ -40,8 +40,26 @@ describe('addUnit', () => {
     expect(addUnit([1, 2], 'px')).toEqual('')
   })
 
+  it.each([null, '', '   ', [], false, true])(
+    'should return empty string with unsupported coercible value %j',
+    (value) => {
+      expect(addUnit(value, 'px')).toBe('')
+    },
+  )
+
   it('should return empty string when formatted value is not finite', () => {
     expect(addUnit(Number.POSITIVE_INFINITY, 'px')).toEqual('')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1, 1.5, 309])(
+    'should return empty string with invalid decimal places %s',
+    (decimalPlaces) => {
+      expect(addUnit(1, 'px', decimalPlaces)).toBe('')
+    },
+  )
+
+  it('should return empty string when rounding overflows', () => {
+    expect(addUnit(Number.MAX_VALUE, 'px', 3)).toBe('')
   })
 
   it('should return unit string without unit', () => {

--- a/packages/utils/src/formatting/css/add-unit/index.ts
+++ b/packages/utils/src/formatting/css/add-unit/index.ts
@@ -2,19 +2,32 @@ import {toNumberOrUndefined} from 'src/formatting/number/to-number'
 import {curryReverse} from 'src/core/functions/curry'
 import {formatCssNumber} from 'src/formatting/css/format-css-number'
 const DEFAULT_DECIMAL_PLACES = 3
+
+const parseCssNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return value
+  }
+
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined
+  }
+
+  return toNumberOrUndefined(value)
+}
+
 /**
- * Appends a CSS unit suffix to a coerced number (no space between number and unit).
- * @param value - Coerced with `toNumberOrUndefined`; unparseable values yield `''`.
+ * Appends a CSS unit suffix to a number or non-empty numeric string.
+ * @param value - Non-numeric and empty values yield `''`.
  * @param unit - Suffix (e.g. `px`, `rem`); default `''` returns digits only.
  * @param decimalPlaces - Rounds via `formatCssNumber` before formatting; default `3`.
- * @returns Unit string, or `''` when `value` cannot be parsed or the number is non-finite after rounding.
+ * @returns Unit string, or `''` when the value and precision cannot produce a finite number.
  */
 export const addUnit = (
   value: unknown,
   unit: string = '',
   decimalPlaces: number = DEFAULT_DECIMAL_PLACES,
 ): string => {
-  const numberValue = toNumberOrUndefined(value)
+  const numberValue = parseCssNumber(value)
 
   if (numberValue === undefined) {
     return ''

--- a/packages/utils/src/formatting/css/format-css-number/__tests__/index.spec.ts
+++ b/packages/utils/src/formatting/css/format-css-number/__tests__/index.spec.ts
@@ -34,4 +34,15 @@ describe('formatCssNumber', () => {
     expect(formatCssNumber(Number.POSITIVE_INFINITY)).toBeUndefined()
     expect(formatCssNumber(Number.NEGATIVE_INFINITY)).toBeUndefined()
   })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1, 1.5, 309])(
+    'should return undefined for invalid decimal places %s',
+    (decimalPlaces) => {
+      expect(formatCssNumber(1, decimalPlaces)).toBeUndefined()
+    },
+  )
+
+  it('should return undefined when rounding overflows', () => {
+    expect(formatCssNumber(Number.MAX_VALUE, 3)).toBeUndefined()
+  })
 })

--- a/packages/utils/src/formatting/css/format-css-number/index.ts
+++ b/packages/utils/src/formatting/css/format-css-number/index.ts
@@ -3,15 +3,25 @@ const ROUNDING_BASE = 10
 /**
  * Rounds a finite number for use in CSS length values.
  * @param value - The number to round.
- * @param decimalPlaces - How many decimal places to keep; default `2`.
- * @returns The rounded value as a string, or `undefined` when `value` is not finite.
+ * @param decimalPlaces - A non-negative integer indicating how many decimal places to keep; default `2`.
+ * @returns The rounded value as a string, or `undefined` when the inputs or result are invalid.
  */
 export const formatCssNumber = (value: number, decimalPlaces: number = 2): string | undefined => {
-  if (!Number.isFinite(value)) {
+  if (!Number.isFinite(value) || !Number.isInteger(decimalPlaces) || decimalPlaces < 0) {
     return undefined
   }
 
-  const scaled = Math.round(value * ROUNDING_BASE ** decimalPlaces) / ROUNDING_BASE ** decimalPlaces
+  const roundingFactor = ROUNDING_BASE ** decimalPlaces
+
+  if (!Number.isFinite(roundingFactor)) {
+    return undefined
+  }
+
+  const scaled = Math.round(value * roundingFactor) / roundingFactor
+
+  if (!Number.isFinite(scaled)) {
+    return undefined
+  }
 
   return String(scaled)
 }


### PR DESCRIPTION
## Summary

- Reject empty and unsupported coercible values in CSS unit formatting
- Validate decimal precision and non-finite rounding results
- Add regression coverage for invalid precision and overflow cases

## Testing

- `pnpm exec vitest run packages/utils/src/formatting/css/add-unit/__tests__/index.spec.ts packages/utils/src/formatting/css/format-css-number/__tests__/index.spec.ts --coverage`
- `pnpm --filter @winter-love/utils typecheck`
- `pnpm exec oxlint packages/utils/src/formatting/css/add-unit/index.ts packages/utils/src/formatting/css/add-unit/__tests__/index.spec.ts packages/utils/src/formatting/css/format-css-number/index.ts packages/utils/src/formatting/css/format-css-number/__tests__/index.spec.ts`
- `pnpm format`